### PR TITLE
Localisation: configurable UI via local.json, variant auto-expand, docs

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -152,9 +152,10 @@ The header has two sides that are independently customisable:
   (left side)                               (right side)
 ```
 
-- **Left side**: controlled by `icon` and `title`.
-- **Right side**: controlled by the `logo` object.  By default it shows
-  `OMW` followed by the Open Multilingual Wordnet logo.  Set `logo.name`
+- **Left side**: controlled by `icon`, `title`, and optionally `url`.
+  By default clicking the title resets the search.  Set `url` to link
+  the title to an external page instead (opens in a new tab).
+- **Right side**: controlled by the `logo` object.  Set `logo.name`
   to show your project's short name to the left of your logo image,
   mirroring the layout of the left side.  Set `logo` to `null` to hide
   the right side entirely.
@@ -167,6 +168,7 @@ The header has two sides that are independently customisable:
 | `name` | value of `title` | Short name used in prose (e.g. "The MWN databases…") |
 | `tagline` | — | Appended to `<title>` as `— tagline` |
 | `icon` | `"🦢"` | Emoji shown to the left of the title in the header |
+| `url` | — | URL for the title link (left side); omit to use click-to-reset-search behaviour |
 | `databases.main.filename` | `"cygnet.db.gz"` | Main DB filename; fetched from the same directory as `index.html` |
 | `databases.main.url` | — | Download URL for the main DB (shown in About tab) |
 | `databases.main.description` | — | One-line description shown in About tab |

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -135,6 +135,9 @@ All fields are optional — omit anything you don't need to override.
     "languageData": "My Wordnet is a standalone resource covering Language X, linked to English via the Princeton WordNet synset hierarchy."
   },
 
+  "searchLanguage": "kaw",
+  "displayLanguage": "kaw",
+
   "publications": [
     "Jane Doe (2025). My Wordnet. In <em>Proceedings of GWC 2025</em>."
   ]
@@ -159,6 +162,8 @@ All fields are optional — omit anything you don't need to override.
 | `about.citation` | — | HTML replacing the citation guidance |
 | `about.languageData` | — | HTML replacing the Language Data paragraph |
 | `publications` | — | HTML strings prepended to the Publications tab list |
+| `searchLanguage` | — | BCP 47 code (or array of codes) to pre-select in the search language filter on load; URL params override this |
+| `displayLanguage` | `"en"` | BCP 47 code for default display language (definitions and synset labels); overridden by `localStorage` if the user has previously changed it manually |
 
 A full template is at [`notes/local.json.example`](notes/local.json.example).
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -1,0 +1,362 @@
+# Using Cygnet for your own project
+
+This guide walks through everything needed to deploy Cygnet's build pipeline
+and web UI for your own wordnet project — from an initial `wordnets.toml` to a
+live GitHub Pages site with downloadable databases.
+
+**Working example:** [davidmoeljadi/OJW](https://github.com/davidmoeljadi/OJW)
+uses exactly this workflow for the Old Javanese Wordnet.
+
+---
+
+## Overview
+
+The end result is:
+
+- `docs/index.html` — the Cygnet web UI, branded for your project
+- `docs/local.json` — your site config
+- `docs/relations.json`, `docs/omw-logo.svg` — supporting UI files
+- Two gzipped SQLite databases attached to a GitHub release:
+  - `myproject.db.gz` — main lexical database
+  - `myproject-provenance.db.gz` — per-row source attribution
+
+The web UI fetches the databases from the GitHub release at runtime, so only
+the small static files need to live in `docs/`.
+
+---
+
+## Prerequisites
+
+- [uv](https://github.com/astral-sh/uv) — Python package manager
+- `curl`, `tar`, `xz`, `wget` (for archive downloads)
+- `xmlstarlet` (for XML manipulation)
+- `libxml2`, `libxslt` (for XML validation)
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y curl tar xz-utils wget xmlstarlet libxml2-dev libxslt-dev
+
+# macOS
+brew install curl wget xmlstarlet libxml2 libxslt
+```
+
+---
+
+## Step 1 — Set up your project directory
+
+Create a directory for your project alongside the cygnet checkout:
+
+```
+myproject/          ← your project
+cygnet/             ← this repo (same parent)
+```
+
+Inside `myproject/`, you need at minimum:
+
+```
+myproject/
+├── etc/
+│   ├── wordnets.toml   ← which wordnets to include
+│   └── local.json      ← UI branding and config
+├── build.sh            ← builds XML → DBs → docs/
+├── run.sh              ← serves docs/ locally for testing
+└── docs/               ← populated by build.sh; served by GitHub Pages
+```
+
+---
+
+## Step 2 — Configure `etc/wordnets.toml`
+
+List every wordnet to include, keyed by BCP 47 language code.  Each entry is a
+list of archive URLs in
+[Global WordNet LMF](https://globalwordnet.github.io/schemas/) format.  The
+first English entry must be OEWN (Open English WordNet), which provides the
+base synset structure.
+
+```toml
+# etc/wordnets.toml
+
+en  = ["https://en-word.net/static/english-wordnet-2025.xml.gz"]
+
+# Add other languages:
+id  = ["https://github.com/omwn/omw-data/releases/download/v2.0/omw-id-2.0.tar.xz"]
+
+# Your own wordnet (pre-built XML will be placed here by build.sh):
+kaw = ["https://github.com/yourorg/yourproject/releases/latest/download/yourwn.tar.xz"]
+```
+
+Archives may be `.xml.gz`, `.tar.gz`, or `.tar.xz`; cygnet's downloader handles
+all three.
+
+---
+
+## Step 3 — Configure `etc/local.json`
+
+All fields are optional — omit anything you don't need to override.
+
+```json
+{
+  "_comment": "Cygnet UI config for My Wordnet.",
+
+  "title":   "My Wordnet",
+  "name":    "MWN",
+  "tagline": "A lexical resource for Language X",
+  "icon":    "📚",
+
+  "db":          "mywn.db.gz",
+  "provenanceDb": "mywn-provenance.db.gz",
+
+  "databases": [
+    {
+      "filename":    "mywn.db.gz",
+      "url":         "https://github.com/yourorg/yourproject/releases/latest/download/mywn.db.gz",
+      "description": "Main lexical database — synsets, senses, forms, definitions, examples."
+    },
+    {
+      "filename":    "mywn-provenance.db.gz",
+      "url":         "https://github.com/yourorg/yourproject/releases/latest/download/mywn-provenance.db.gz",
+      "description": "Provenance records tracing every data point back to its source."
+    }
+  ],
+
+  "logo": {
+    "src": "mylogo.svg",
+    "url": "https://github.com/yourorg/yourproject",
+    "alt": "My Wordnet"
+  },
+
+  "header": "<strong>Preview build</strong> — data updated 2025-01-01.",
+
+  "footer": "Built by the <a href='https://yourlab.org' style='text-decoration:underline'>Your Lab</a> team.",
+
+  "about": {
+    "intro": "<p>My Wordnet covers Language X.</p><p>Developed by Jane Doe. Source code on <a href='https://github.com/yourorg/yourproject' style='text-decoration:underline'>GitHub</a>.</p>",
+    "citation": "If you use My Wordnet, please cite Doe (2025).",
+    "languageData": "My Wordnet is a standalone resource covering Language X, linked to English via the Princeton WordNet synset hierarchy."
+  },
+
+  "publications": [
+    "Jane Doe (2025). My Wordnet. In <em>Proceedings of GWC 2025</em>."
+  ]
+}
+```
+
+### Field reference
+
+| Field | Default | Effect |
+|---|---|---|
+| `title` | `"Cygnet"` | Page `<title>` and header heading |
+| `name` | value of `title` | Short name used in prose (e.g. "The MWN databases…") |
+| `tagline` | — | Appended to `<title>` as `— tagline` |
+| `icon` | `"🦢"` | Emoji in header and as favicon |
+| `db` | `"cygnet.db.gz"` | Main DB filename (relative path, served alongside `index.html`) |
+| `provenanceDb` | `"provenance.db.gz"` | Provenance DB filename |
+| `databases` | auto-computed | Download list shown in the About tab; each entry has `filename`, `url`, `description` |
+| `logo` | OMW logo | Header logo object `{src, url, alt}`; `null` to hide |
+| `header` | — | HTML banner shown below the nav bar |
+| `footer` | Cygnet credit | HTML footer |
+| `about.intro` | — | HTML replacing the About intro paragraphs |
+| `about.citation` | — | HTML replacing the citation guidance |
+| `about.languageData` | — | HTML replacing the Language Data paragraph |
+| `publications` | — | HTML strings prepended to the Publications tab list |
+
+A full template is at [`notes/local.json.example`](notes/local.json.example).
+
+---
+
+## Step 4 — Write `build.sh`
+
+Your `build.sh` should:
+
+1. Build your wordnet XML (project-specific)
+2. Call `cygnet/build.sh --work-dir` to run the pipeline
+3. Copy the UI and databases to `docs/`
+
+Minimal example (adapt to your own XML build):
+
+```bash
+#!/usr/bin/env bash
+#
+# build.sh — builds myproject databases and deploys the web UI to docs/.
+#
+# Usage: bash build.sh
+# Outputs:
+#   docs/            — web UI ready for GitHub Pages
+#   build/mywn-*.tar.xz — packaged WordNet LMF archive (for release)
+
+set -euo pipefail
+
+VERSION="2026.01.01"
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CYGNET_DIR="$(cd "$PROJECT_DIR/../cygnet" && pwd)"
+CYGNET_WORK="$PROJECT_DIR/build/cygnet-work"
+
+# ── 1. Build your wordnet XML ────────────────────────────────────────────────
+# (your own steps here — produce build/mywn-VERSION/mywn-VERSION.xml)
+
+# ── 2. Run the Cygnet pipeline ───────────────────────────────────────────────
+mkdir -p "$CYGNET_WORK/bin/raw_wns"
+cp "$PROJECT_DIR/etc/wordnets.toml" "$CYGNET_WORK/wordnets.toml"
+cp "$PROJECT_DIR/build/mywn-$VERSION/mywn-$VERSION.xml" \
+   "$CYGNET_WORK/bin/raw_wns/mywn-$VERSION.xml"
+
+bash "$CYGNET_DIR/build.sh" --work-dir "$CYGNET_WORK"
+
+# ── 3. Deploy to docs/ ───────────────────────────────────────────────────────
+mkdir -p "$PROJECT_DIR/docs"
+cp "$CYGNET_DIR/web/index.html"          "$PROJECT_DIR/docs/"
+cp "$CYGNET_DIR/web/relations.json"      "$PROJECT_DIR/docs/"
+cp "$CYGNET_DIR/web/omw-logo.svg"        "$PROJECT_DIR/docs/" 2>/dev/null || true
+cp "$PROJECT_DIR/etc/local.json"         "$PROJECT_DIR/docs/"
+cp "$CYGNET_WORK/web/cygnet.db.gz"       "$PROJECT_DIR/docs/mywn.db.gz"
+cp "$CYGNET_WORK/web/provenance.db.gz"   "$PROJECT_DIR/docs/mywn-provenance.db.gz"
+```
+
+The `--work-dir` flag tells cygnet's pipeline to use that directory for
+intermediate files instead of cygnet's own `bin/` and `web/`.  Cygnet also
+seeds the work directory's `wordnets.toml` from the provided one and skips
+running the test suite (tests are cygnet-internal).
+
+---
+
+## Step 5 — Add `run.sh` for local testing
+
+```bash
+#!/usr/bin/env bash
+# Serve docs/ locally for testing.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec bash "$SCRIPT_DIR/../cygnet/run.sh" "$SCRIPT_DIR/docs"
+```
+
+After running `bash build.sh`, start the server with:
+
+```bash
+bash run.sh
+```
+
+The terminal prints a URL like `http://localhost:8801`.  Open it in a browser —
+the UI reads `docs/local.json` and loads `docs/mywn.db.gz` directly from the
+local server.
+
+---
+
+## Step 6 — Set up `.gitignore`
+
+The database files are large binaries that belong in a GitHub release, not in
+git history.  Add them to `.gitignore`:
+
+```
+*~
+.venv/
+build/
+external/
+docs/*.db.gz
+```
+
+Commit `docs/index.html`, `docs/relations.json`, `docs/omw-logo.svg`, and
+`docs/local.json` — these are small and needed for GitHub Pages to serve the
+UI.
+
+---
+
+## Step 7 — Enable GitHub Pages
+
+1. Go to your repository on GitHub → **Settings → Pages**.
+2. Under *Source*, choose **Deploy from a branch**.
+3. Select branch `main` (or `master`) and folder **`/docs`**.
+4. Click **Save**.
+
+GitHub will publish `https://<org>.github.io/<repo>/` within a minute.  The UI
+will load but show an error fetching the database until you complete the next
+step.
+
+---
+
+## Step 8 — Create a GitHub release and attach the databases
+
+The browser fetches the databases from the URLs you listed in `local.json`'s
+`databases` array.  Those URLs should point to GitHub release assets.
+
+### Option A — release manually via the CLI
+
+```bash
+# Tag the release
+git tag 2026.01.01
+git push origin 2026.01.01
+
+# Create the release and upload the databases
+gh release create 2026.01.01 \
+  --title "My Wordnet 2026.01.01" \
+  --notes "Initial release." \
+  docs/mywn.db.gz \
+  docs/mywn-provenance.db.gz
+```
+
+If you also package your wordnet as a WordNet LMF archive (recommended, for
+interoperability), attach that too:
+
+```bash
+gh release create 2026.01.01 \
+  --title "My Wordnet 2026.01.01" \
+  --notes "Initial release." \
+  docs/mywn.db.gz \
+  docs/mywn-provenance.db.gz \
+  build/mywn-2026.01.01.tar.xz
+```
+
+### Option B — release via the GitHub web UI
+
+1. Go to **Releases → Draft a new release**.
+2. Create a new tag (e.g. `2026.01.01`).
+3. Drag `mywn.db.gz`, `mywn-provenance.db.gz` (and optionally the `.tar.xz`)
+   into the asset upload box.
+4. Click **Publish release**.
+
+### Recommended: automate with GitHub Actions
+
+For repeatable releases, add a workflow that builds and uploads the databases
+automatically.  See cygnet's own
+[`.github/workflows/release.yml`](../.github/workflows/release.yml) for a
+complete example — it caches the downloaded source archives so re-builds are
+fast.
+
+---
+
+## Step 9 — Verify the live site
+
+Open `https://<org>.github.io/<repo>/` in a browser.
+
+- The page should show your project name and branding.
+- The About tab should list your databases with the correct filenames and URLs.
+- Clicking the download links should reach the release assets.
+- The browser will fetch and decompress the database automatically on first
+  load, then cache it in IndexedDB for subsequent visits.
+
+If the old Cygnet databases appear instead of yours, the browser has cached an
+older version.  The cache is invalidated automatically when the DB filename or
+server modification time changes.  You can also force a reset via
+**About → Cache → Clear cached database**.
+
+---
+
+## Updating to a new Cygnet release
+
+When a new version of cygnet is released:
+
+1. Pull the latest cygnet code: `git -C ../cygnet pull`
+2. Re-run `bash build.sh` in your project directory to regenerate `docs/` with
+   the updated `index.html`, `relations.json`, and databases.
+3. Commit the updated `docs/` static files and publish a new release with the
+   new databases attached.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| UI shows `myproject.db.gz` names | Running `cygnet/run.sh` directly instead of your project's `run.sh` | Run `bash run.sh` from your project directory |
+| No wordnets / empty browser tab | DB not loaded; check browser console | Confirm the DB file is in `docs/` (for local testing) or published as a release asset (for production) |
+| DB filename appears but no data | `wordnets.toml` URLs unreachable during build | Check for download errors in build output |
+| "Expected OEWN first" error | `wordnets.toml` lists a non-OEWN wordnet first for `en` | Put the OEWN URL first under `en` |
+| Pages shows old content | GitHub Pages cache | Wait a minute; hard-reload with Ctrl+Shift+R |

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -156,8 +156,6 @@ All fields are optional — omit anything you don't need to override.
 | `databases.provenance.filename` | `"provenance.db.gz"` | Provenance DB filename; same directory as `index.html` |
 | `databases.provenance.url` | — | Download URL for the provenance DB (shown in About tab) |
 | `databases.provenance.description` | — | One-line description shown in About tab |
-| `db` | — | Deprecated: use `databases.main.filename` instead |
-| `provenanceDb` | — | Deprecated: use `databases.provenance.filename` instead |
 | `logo` | OMW logo | Header logo object `{src, url, alt}`; `null` to hide |
 | `header` | — | HTML banner shown below the nav bar |
 | `footer` | Cygnet credit | HTML footer |
@@ -282,10 +280,9 @@ step.
 
 ## Step 8 — Create a GitHub release and attach the databases
 
-The `db` and `provenanceDb` fields in `local.json` tell the UI which files to
-load — they are fetched from the same directory as `index.html`.  The
-`databases` array is only used for the About-tab download links; it does not
-affect which files the browser loads.
+The UI reads `databases.main.filename` and `databases.provenance.filename` to
+decide which database files to load (from the same directory as `index.html`).
+These same entries drive the About-tab download links.
 
 ### Option A — release manually via the CLI
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -104,21 +104,18 @@ All fields are optional — omit anything you don't need to override.
   "tagline": "A lexical resource for Language X",
   "icon":    "📚",
 
-  "db":          "mywn.db.gz",
-  "provenanceDb": "mywn-provenance.db.gz",
-
-  "databases": [
-    {
+  "databases": {
+    "main": {
       "filename":    "mywn.db.gz",
       "url":         "https://github.com/yourorg/yourproject/releases/latest/download/mywn.db.gz",
       "description": "Main lexical database — synsets, senses, forms, definitions, examples."
     },
-    {
+    "provenance": {
       "filename":    "mywn-provenance.db.gz",
       "url":         "https://github.com/yourorg/yourproject/releases/latest/download/mywn-provenance.db.gz",
       "description": "Provenance records tracing every data point back to its source."
     }
-  ],
+  },
 
   "logo": {
     "src": "mylogo.svg",
@@ -153,9 +150,14 @@ All fields are optional — omit anything you don't need to override.
 | `name` | value of `title` | Short name used in prose (e.g. "The MWN databases…") |
 | `tagline` | — | Appended to `<title>` as `— tagline` |
 | `icon` | `"🦢"` | Emoji in header and as favicon |
-| `db` | `"cygnet.db.gz"` | Main DB filename; fetched from the same directory as `index.html` |
-| `provenanceDb` | `"provenance.db.gz"` | Provenance DB filename; same directory as `index.html` |
-| `databases` | auto-computed | Download list shown in the About tab; each entry has `filename`, `url`, `description` |
+| `databases.main.filename` | `"cygnet.db.gz"` | Main DB filename; fetched from the same directory as `index.html` |
+| `databases.main.url` | — | Download URL for the main DB (shown in About tab) |
+| `databases.main.description` | — | One-line description shown in About tab |
+| `databases.provenance.filename` | `"provenance.db.gz"` | Provenance DB filename; same directory as `index.html` |
+| `databases.provenance.url` | — | Download URL for the provenance DB (shown in About tab) |
+| `databases.provenance.description` | — | One-line description shown in About tab |
+| `db` | — | Deprecated: use `databases.main.filename` instead |
+| `provenanceDb` | — | Deprecated: use `databases.provenance.filename` instead |
 | `logo` | OMW logo | Header logo object `{src, url, alt}`; `null` to hide |
 | `header` | — | HTML banner shown below the nav bar |
 | `footer` | Cygnet credit | HTML footer |

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -120,7 +120,8 @@ All fields are optional — omit anything you don't need to override.
   "logo": {
     "src": "mylogo.svg",
     "url": "https://github.com/yourorg/yourproject",
-    "alt": "My Wordnet"
+    "alt": "My Wordnet",
+    "name": "MWN"
   },
 
   "header": "<strong>Preview build</strong> — data updated 2025-01-01.",
@@ -142,21 +143,41 @@ All fields are optional — omit anything you don't need to override.
 }
 ```
 
+### Header layout
+
+The header has two sides that are independently customisable:
+
+```
+[ icon  title ]                          [ logo.name  logo.src ]
+  (left side)                               (right side)
+```
+
+- **Left side**: controlled by `icon` and `title`.
+- **Right side**: controlled by the `logo` object.  By default it shows
+  `OMW` followed by the Open Multilingual Wordnet logo.  Set `logo.name`
+  to show your project's short name to the left of your logo image,
+  mirroring the layout of the left side.  Set `logo` to `null` to hide
+  the right side entirely.
+
 ### Field reference
 
 | Field | Default | Effect |
 |---|---|---|
-| `title` | `"Cygnet"` | Page `<title>` and header heading |
+| `title` | `"Cygnet"` | Page `<title>` and header heading (left side) |
 | `name` | value of `title` | Short name used in prose (e.g. "The MWN databases…") |
 | `tagline` | — | Appended to `<title>` as `— tagline` |
-| `icon` | `"🦢"` | Emoji in header and as favicon |
+| `icon` | `"🦢"` | Emoji shown to the left of the title in the header |
 | `databases.main.filename` | `"cygnet.db.gz"` | Main DB filename; fetched from the same directory as `index.html` |
 | `databases.main.url` | — | Download URL for the main DB (shown in About tab) |
 | `databases.main.description` | — | One-line description shown in About tab |
 | `databases.provenance.filename` | `"provenance.db.gz"` | Provenance DB filename; same directory as `index.html` |
 | `databases.provenance.url` | — | Download URL for the provenance DB (shown in About tab) |
 | `databases.provenance.description` | — | One-line description shown in About tab |
-| `logo` | OMW logo | Header logo object `{src, url, alt}`; `null` to hide |
+| `logo` | OMW logo | Header logo object `{src, url, alt, name}`; `null` to hide right side |
+| `logo.src` | — | Image path (relative to `index.html`) or URL |
+| `logo.url` | — | Link URL; omit to render image without a hyperlink |
+| `logo.alt` | `""` | Alt text for the logo image |
+| `logo.name` | — | Short text shown to the left of the logo image (same bold style as `title`) |
 | `header` | — | HTML banner shown below the nav bar |
 | `footer` | Cygnet credit | HTML footer |
 | `about.intro` | — | HTML replacing the About intro paragraphs |

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -199,7 +199,45 @@ Your `build.sh` should:
 2. Call `cygnet/build.sh --work-dir` to run the pipeline
 3. Copy the UI and databases to `docs/`
 
-Minimal example (adapt to your own XML build):
+### Starting from a `.tab` file (OMW TSV format)
+
+Many Open Multilingual Wordnet resources are distributed as `.tab` files rather
+than WN-LMF XML.  To convert, use the `tsv2lmf.py` script from the
+[omw-data](https://github.com/omwn/omw-data) repository and the ILI map from
+[cili](https://github.com/globalwordnet/cili):
+
+```bash
+git clone https://github.com/omwn/omw-data.git external/omw-data
+git clone https://github.com/globalwordnet/cili.git external/cili
+
+pushd external/omw-data/scripts
+python3 tsv2lmf.py \
+    "$OLDPWD/my-wordnet.tab" \
+    "$OLDPWD/build/mywn-VERSION/mywn-VERSION.xml" \
+    --id='mywn' \
+    --label='My Wordnet' \
+    --language='xyz' \
+    --version="$VERSION" \
+    --email='contact@example.org' \
+    --license='https://creativecommons.org/licenses/by/4.0/' \
+    --url='https://github.com/yourorg/yourproject' \
+    --citation="$(cat etc/citation.rst)" \
+    --requires=omw-en:2.0 \
+    --ili-map="$OLDPWD/external/cili/ili-map-pwn30.tab"
+popd
+```
+
+The `.tab` header line must have **four** tab-separated fields (after `##`):
+`label`, `language`, `url`, `license`.  If your file only has three (no URL),
+prepend a fixed header before passing it to `tsv2lmf.py`:
+
+```bash
+{ printf '## My Wordnet\txyz\thttps://github.com/yourorg/yourproject\tCC BY 4.0\n'
+  tail -n +2 my-wordnet.tab
+} > build/my-wordnet-fixed.tab
+```
+
+### Minimal `build.sh` example (adapt to your own XML build):
 
 ```bash
 #!/usr/bin/env bash
@@ -364,6 +402,37 @@ If the old Cygnet databases appear instead of yours, the browser has cached an
 older version.  The cache is invalidated automatically when the DB filename or
 server modification time changes.  You can also force a reset via
 **About → Cache → Clear cached database**.
+
+---
+
+## ARASAAC pictogram images
+
+Cygnet displays [ARASAAC](https://arasaac.org) pictograms alongside synsets
+when a matching image exists.  The mapping from synset ILIs to pictogram IDs
+is pre-built and committed to the cygnet repo at `data/araasac-ili.json`.
+
+When you build with `--work-dir`, cygnet automatically copies this file into
+your work directory so the ARASAAC step works without any extra configuration.
+
+**To regenerate the mapping** (e.g. after ARASAAC releases new pictograms):
+
+```bash
+cd /path/to/cygnet
+uv run conversion_scripts/11_add_arasaac.py --rebuild
+git add data/araasac-ili.json
+git commit -m "Refresh ARASAAC ILI mapping"
+```
+
+**To patch an existing external database** without a full rebuild:
+
+```bash
+cp /path/to/cygnet/data/araasac-ili.json myproject/build/cygnet-work/data/
+cd myproject/build/cygnet-work
+uv run --project /path/to/cygnet \
+    python3 /path/to/cygnet/conversion_scripts/11_add_arasaac.py
+gzip -k -9 -f web/cygnet.db
+cp web/cygnet.db.gz myproject/docs/mywn.db.gz
+```
 
 ---
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -20,8 +20,9 @@ The end result is:
   - `myproject.db.gz` — main lexical database
   - `myproject-provenance.db.gz` — per-row source attribution
 
-The web UI fetches the databases from the GitHub release at runtime, so only
-the small static files need to live in `docs/`.
+The databases are large — they are attached to a GitHub release rather than
+committed to the repo.  The Pages deployment step (or a local build) places
+them in `docs/` alongside `index.html`, where the browser loads them.
 
 ---
 
@@ -152,8 +153,8 @@ All fields are optional — omit anything you don't need to override.
 | `name` | value of `title` | Short name used in prose (e.g. "The MWN databases…") |
 | `tagline` | — | Appended to `<title>` as `— tagline` |
 | `icon` | `"🦢"` | Emoji in header and as favicon |
-| `db` | `"cygnet.db.gz"` | Main DB filename (relative path, served alongside `index.html`) |
-| `provenanceDb` | `"provenance.db.gz"` | Provenance DB filename |
+| `db` | `"cygnet.db.gz"` | Main DB filename; fetched from the same directory as `index.html` |
+| `provenanceDb` | `"provenance.db.gz"` | Provenance DB filename; same directory as `index.html` |
 | `databases` | auto-computed | Download list shown in the About tab; each entry has `filename`, `url`, `description` |
 | `logo` | OMW logo | Header logo object `{src, url, alt}`; `null` to hide |
 | `header` | — | HTML banner shown below the nav bar |
@@ -279,8 +280,10 @@ step.
 
 ## Step 8 — Create a GitHub release and attach the databases
 
-The browser fetches the databases from the URLs you listed in `local.json`'s
-`databases` array.  Those URLs should point to GitHub release assets.
+The `db` and `provenanceDb` fields in `local.json` tell the UI which files to
+load — they are fetched from the same directory as `index.html`.  The
+`databases` array is only used for the About-tab download links; it does not
+affect which files the browser loads.
 
 ### Option A — release manually via the CLI
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,56 @@ WebAssembly).  No server-side component is needed after the initial file loads.
 
 See [`WEB_UI.md`](WEB_UI.md) for developer documentation.
 
+### Customising the web UI
+
+To deploy `web/index.html` for a different project, create a `web/local.json`
+file alongside it.  All fields are optional — omit any you don't need:
+
+```json
+{
+  "title":       "My Wordnet",
+  "tagline":     "A multilingual lexical resource",
+  "icon":        "📚",
+
+  "db":          "myproject.db.gz",
+  "provenanceDb":"myproject-provenance.db.gz",
+
+  "logo": {
+    "src": "mylogo.svg",
+    "url": "https://myproject.org",
+    "alt": "My Project"
+  },
+
+  "header": "<strong>Preview build</strong> — data updated 2025-01-01.",
+  "footer": "Built by the <a href='https://mylab.org'>My Lab</a> team.",
+
+  "about": {
+    "intro":    "<p>My Wordnet covers X languages…</p>",
+    "citation": "If you use this resource, please cite Doe (2025)."
+  },
+
+  "publications": [
+    "Jane Doe (2025). My Wordnet. In <em>Proceedings of GWC 2025</em>."
+  ]
+}
+```
+
+| Field | Effect |
+|---|---|
+| `title` | Header h1 and browser `<title>` |
+| `tagline` | Appended to `<title>` as `— tagline` |
+| `icon` | Emoji shown in the header and as the favicon |
+| `db` | Main database filename (default: `cygnet.db.gz`) |
+| `provenanceDb` | Provenance database filename |
+| `logo` | Header logo (`{src, url, alt}`); set to `null` to hide it |
+| `header` | HTML banner below the nav bar |
+| `footer` | HTML replacing the footer |
+| `about.intro` | HTML replacing the About tab intro paragraphs |
+| `about.citation` | HTML replacing the citation guidance in About |
+| `publications` | HTML strings prepended to the Publications list |
+
+A template is available at [`notes/local.json.example`](notes/local.json.example).
+
 ---
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ file alongside it.  All fields are optional — omit any you don't need:
 | `title` | Header h1 and browser `<title>` |
 | `tagline` | Appended to `<title>` as `— tagline` |
 | `icon` | Emoji shown in the header and as the favicon |
+| `url` | URL for the title (left side of header); omit to use click-to-home behaviour |
 | `databases.main` | Main DB: `filename` (loaded by the UI) and `url` + `description` (shown in About tab) |
 | `databases.provenance` | Provenance DB: same fields |
 | `logo` | Header logo (`{src, url, alt, name}`); `name` shown left of image; `null` to hide |

--- a/README.md
+++ b/README.md
@@ -157,8 +157,10 @@ file alongside it.  All fields are optional — omit any you don't need:
   "tagline":     "A multilingual lexical resource",
   "icon":        "📚",
 
-  "db":          "myproject.db.gz",
-  "provenanceDb":"myproject-provenance.db.gz",
+  "databases": {
+    "main":       { "filename": "myproject.db.gz",            "url": "https://github.com/myorg/myproject/releases/latest/download/myproject.db.gz" },
+    "provenance": { "filename": "myproject-provenance.db.gz", "url": "https://github.com/myorg/myproject/releases/latest/download/myproject-provenance.db.gz" }
+  },
 
   "logo": {
     "src": "mylogo.svg",
@@ -185,8 +187,8 @@ file alongside it.  All fields are optional — omit any you don't need:
 | `title` | Header h1 and browser `<title>` |
 | `tagline` | Appended to `<title>` as `— tagline` |
 | `icon` | Emoji shown in the header and as the favicon |
-| `db` | Main database filename (default: `cygnet.db.gz`) |
-| `provenanceDb` | Provenance database filename |
+| `databases.main` | Main DB: `filename` (loaded by the UI) and `url` + `description` (shown in About tab) |
+| `databases.provenance` | Provenance DB: same fields |
 | `logo` | Header logo (`{src, url, alt}`); set to `null` to hide it |
 | `header` | HTML banner below the nav bar |
 | `footer` | HTML replacing the footer |

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ file alongside it.  All fields are optional — omit any you don't need:
 | `about.citation` | HTML replacing the citation guidance in About |
 | `publications` | HTML strings prepended to the Publications list |
 
-A template is available at [`notes/local.json.example`](notes/local.json.example).
+This table lists the most commonly used fields. For the full reference (including `name`, `databases`, `about.languageData`, `searchLanguage`, `displayLanguage`, and more) see [`CUSTOMIZE.md`](CUSTOMIZE.md) or the annotated template at [`notes/local.json.example`](notes/local.json.example).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ See [`WEB_UI.md`](WEB_UI.md) for developer documentation.
 
 ### Customising the web UI
 
+For a full guide to deploying Cygnet for your own project — including
+`wordnets.toml`, `local.json`, `build.sh`, releases, and GitHub Pages — see
+**[`CUSTOMIZE.md`](CUSTOMIZE.md)**.  The
+[Old Javanese Wordnet](https://github.com/davidmoeljadi/OJW) is a working
+example.
+
 To deploy `web/index.html` for a different project, create a `web/local.json`
 file alongside it.  All fields are optional — omit any you don't need:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ file alongside it.  All fields are optional — omit any you don't need:
   "logo": {
     "src": "mylogo.svg",
     "url": "https://myproject.org",
-    "alt": "My Project"
+    "alt": "My Project",
+    "name": "MWN"
   },
 
   "header": "<strong>Preview build</strong> — data updated 2025-01-01.",
@@ -189,12 +190,14 @@ file alongside it.  All fields are optional — omit any you don't need:
 | `icon` | Emoji shown in the header and as the favicon |
 | `databases.main` | Main DB: `filename` (loaded by the UI) and `url` + `description` (shown in About tab) |
 | `databases.provenance` | Provenance DB: same fields |
-| `logo` | Header logo (`{src, url, alt}`); set to `null` to hide it |
+| `logo` | Header logo (`{src, url, alt, name}`); `name` shown left of image; `null` to hide |
 | `header` | HTML banner below the nav bar |
 | `footer` | HTML replacing the footer |
 | `about.intro` | HTML replacing the About tab intro paragraphs |
 | `about.citation` | HTML replacing the citation guidance in About |
 | `publications` | HTML strings prepended to the Publications list |
+
+Fields marked as "HTML" (`header`, `footer`, `about.*`, `publications`) are injected as raw HTML — treat them as trusted configuration, equivalent to editing the HTML file directly. Do not populate them from untrusted user input.
 
 This table lists the most commonly used fields. For the full reference (including `name`, `databases`, `about.languageData`, `searchLanguage`, `displayLanguage`, and more) see [`CUSTOMIZE.md`](CUSTOMIZE.md) or the annotated template at [`notes/local.json.example`](notes/local.json.example).
 

--- a/WEB_UI.md
+++ b/WEB_UI.md
@@ -45,17 +45,22 @@ The whole UI is a single `App` component.  Important state:
 |---|---|---|
 | `dbReady` | `false` | True once sql.js + DB are initialised |
 | `relConfigLoaded` | `false` | True once `relations.json` has loaded; triggers label re-render |
-| `activeTab` | `'browser'` | Top-level tab: `browser`, `python`, `data`, `about`, `publications`, `wordnets` |
-| `view` | `'search'` | Within the browser tab: `search` or `concept` |
+| `siteConfig` | `{}` | Loaded from `local.json`; controls branding, DB filenames, language defaults |
+| `activeTab` | `'browser'` | Top-level tab: `browser`, `about`, `publications`, `wordnets` |
+| `view` | `'search'` | Within the browser tab: `search`, `concept`, or `sense` |
 | `relationsView` | `localStorage` / `'graph'` | How concept relations are displayed: `graph`, `text`, `none` |
 | `selectedConcept` | `null` | Synset rowid of currently open concept |
 | `selectedSense` | `null` | Sense rowid of currently open sense |
+| `languageFilter` | `new Set()` | Active search language filter (BCP 47 codes); seeded from `local.json` `searchLanguage` |
+| `definitionLanguage` | `localStorage` / `'en'` | Display language for definitions and synset labels; seeded from `local.json` `displayLanguage` if no localStorage value |
+| `synonymsCollapsed` | `{}` | Per-sense expansion state: `false` = expanded, `true` = explicitly collapsed, absent = default |
 
 Key `useEffect` hooks (in order):
 1. **`relations.json` fetch** — runs on mount; populates `_relConfig`, calls `_buildRelLookups()`, sets `relConfigLoaded`
-2. **DB init** — runs on mount; loads sql.js, fetches/decompresses `cygnet.db.gz`, sets up the DB
-3. **Provenance DB** — loads `provenance.db.gz` on demand when user clicks "Load provenance data"
-4. **URL sync** — keeps `window.location.hash` in sync with current view/search/concept
+2. **`local.json` / site config** — runs on mount; awaits `_configPromise`, sets `siteConfig` and applies `searchLanguage`/`displayLanguage` defaults
+3. **DB init** — runs on mount; awaits `_configPromise`, loads sql.js, fetches/decompresses the DB (with IndexedDB caching keyed by filename + mtime), sets up the DB
+4. **Provenance DB** — loads provenance DB on demand when user clicks "Load provenance data"
+5. **URL sync** — keeps `window.location.hash` in sync with current view/search/concept/filters
 
 ---
 
@@ -90,9 +95,7 @@ Each entry maps a **DB relation name** to its display metadata:
 | `activeTab` value | Label shown | Contents |
 |---|---|---|
 | `browser` | Browser | Search + concept/sense view |
-| `python` | Python | Placeholder |
-| `data` | Data | Download links |
-| `about` | About | Citation guidance, language data, images, ARASAAC info |
+| `about` | About | Download links, citation guidance, language data, ARASAAC info |
 | `publications` | Publications | Key papers + wordnet citations from DB |
 | `wordnets` | Wordnets | Per-resource table with concept/sense counts, licences, citations |
 
@@ -130,7 +133,7 @@ uv run pytest tests/test_ui.py -v
 
 ### Add a new top-level tab
 
-1. Add the tab ID to the array in the `{['browser', 'python', ...].map(tab => ...)}` render block (~line 1671).
+1. Add the tab ID to the array in the `{['browser', 'about', 'publications', 'wordnets'].map(tab => ...)}` render block.
 2. Add a `{activeTab === 'newtab' && ...}` block in the tab content section below.
 
 ### Add a new relation type

--- a/build.sh
+++ b/build.sh
@@ -83,6 +83,8 @@ if [[ -n "$WORK_DIR" ]]; then
     if [[ ! -f "$DATA_DIR/wordnets.toml" ]]; then
         cp "$PROJECT_DIR/wordnets.toml" "$DATA_DIR/wordnets.toml"
     fi
+    # 7_validate_and_export.py reads cygnet.xsd from cwd; copy it into DATA_DIR.
+    cp "$PROJECT_DIR/cygnet.xsd" "$DATA_DIR/cygnet.xsd"
 else
     DATA_DIR="$PROJECT_DIR"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # build.sh - Download wordnets and build Cygnet
 #
@@ -11,6 +11,11 @@
 #   bin/araasac-ili.json  ARASAAC pictogram ILI mapping (from chainnet-viz)
 #
 # Optional flags:
+#   --work-dir DIR     Use DIR as the data/output root instead of this
+#                      project directory. bin/, web/ etc. are created there.
+#                      wordnets.toml is read from DIR if present, otherwise
+#                      copied from the project directory. Tests are skipped
+#                      automatically when --work-dir is given.
 #   --with-glosstag    Add Princeton GlossTag sense annotations to definitions
 #                      (requires WordNet 3.0 GlossTag corpus in bin/WordNet-3.0/)
 #   --with-translate   Machine-translate non-English glosses to English
@@ -19,6 +24,7 @@
 #                      (requires xmlstarlet; slow — 678 MB output)
 #   --download-only    Download data without running the build
 #   --build-only       Run the build without downloading (assumes data exists)
+#   --skip-tests       Skip the test suite
 #
 set -euo pipefail
 
@@ -33,22 +39,27 @@ WITH_XML=false
 DO_DOWNLOAD=true
 DO_BUILD=true
 DO_TESTS=true
+WORK_DIR=""
 
-for arg in "$@"; do
-    case "$arg" in
-        --with-glosstag)  WITH_GLOSSTAG=true ;;
-        --with-translate) WITH_TRANSLATE=true ;;
-        --with-xml)       WITH_XML=true ;;
-        --download-only)  DO_BUILD=false ;;
-        --build-only)     DO_DOWNLOAD=false ;;
-        --skip-tests)     DO_TESTS=false ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --work-dir)
+            WORK_DIR="$2"
+            shift 2
+            ;;
+        --with-glosstag)  WITH_GLOSSTAG=true;  shift ;;
+        --with-translate) WITH_TRANSLATE=true; shift ;;
+        --with-xml)       WITH_XML=true;        shift ;;
+        --download-only)  DO_BUILD=false;       shift ;;
+        --build-only)     DO_DOWNLOAD=false;    shift ;;
+        --skip-tests)     DO_TESTS=false;       shift ;;
         --help|-h)
             sed -n '3,/^$/{ s/^# \?//; p }' "$0"
             exit 0
             ;;
         *)
-            echo "Unknown argument: $arg"
-            echo "Run with --help for usage."
+            echo "Unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
             exit 1
             ;;
     esac
@@ -58,7 +69,26 @@ done
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$PROJECT_DIR"
 
-mkdir -p bin/raw_wns bin/cygnets_presynth
+if [[ -n "$WORK_DIR" ]]; then
+    mkdir -p "$WORK_DIR"
+    DATA_DIR="$(cd "$WORK_DIR" && pwd)"
+    # Tests test the cygnet database, not an external work dir.
+    DO_TESTS=false
+    # Use the caller's wordnets.toml if present; otherwise seed from project.
+    if [[ ! -f "$DATA_DIR/wordnets.toml" ]]; then
+        cp "$PROJECT_DIR/wordnets.toml" "$DATA_DIR/wordnets.toml"
+    fi
+else
+    DATA_DIR="$PROJECT_DIR"
+fi
+
+mkdir -p "$DATA_DIR/bin/raw_wns" "$DATA_DIR/bin/cygnets_presynth" "$DATA_DIR/web"
+
+# Run a conversion script from DATA_DIR using cygnet's Python environment.
+run_pipeline() {
+    (cd "$DATA_DIR" && uv run --project "$PROJECT_DIR" \
+        python "$PROJECT_DIR/conversion_scripts/$1" "${@:2}")
+}
 
 # Download a wordnet archive and extract its XML files into bin/raw_wns/ (flat).
 download_standalone() {
@@ -66,20 +96,19 @@ download_standalone() {
     echo "  Downloading $name..."
     local tmpdir
     tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
     curl -fSL -o "$tmpdir/archive" "$url"
     tar xf "$tmpdir/archive" -C "$tmpdir/"
-    # Copy all wordnet XML files (plain, gzipped, or xz-compressed)
     find "$tmpdir" \( -name '*.xml' -o -name '*.xml.gz' -o -name '*.xml.xz' \) \
-        -exec cp --update=none {} bin/raw_wns/ \;
-    rm -rf "$tmpdir"
+        -exec cp -n {} "$DATA_DIR/bin/raw_wns/" \;
 }
 
 # Parse wordnets.toml and emit "stem<TAB>url" lines (no tomllib dependency needed).
 get_wordnet_urls() {
-    python3 << 'PYEOF'
+    python3 - "$DATA_DIR/wordnets.toml" << 'PYEOF'
 import re, sys
 
-content = open("wordnets.toml").read()
+content = open(sys.argv[1]).read()
 
 def stem(url):
     name = url.rstrip("/").split("/")[-1]
@@ -106,32 +135,30 @@ if $DO_DOWNLOAD; then
     # CILI (Collaborative Interlingual Index)
     # Script 1 expects columns: ili_id, status, superseded_by, origin, definition
     # The release TSV only has ILI+Definition, so we merge it with the PWN 3.0 mapping.
-    if [ ! -f bin/cili.tsv ]; then
+    if [ ! -f "$DATA_DIR/bin/cili.tsv" ]; then
         echo "  Downloading CILI..."
-        curl -fSL -o bin/cili_defs.tsv.xz "$CILI_DEFS_URL"
-        xz -d bin/cili_defs.tsv.xz
-        curl -fSL -o bin/cili_pwn_map.tab "$CILI_PWN_MAP_URL"
+        curl -fSL -o "$DATA_DIR/bin/cili_defs.tsv.xz" "$CILI_DEFS_URL"
+        xz -d "$DATA_DIR/bin/cili_defs.tsv.xz"
+        curl -fSL -o "$DATA_DIR/bin/cili_pwn_map.tab" "$CILI_PWN_MAP_URL"
         python3 -c "
 import csv, sys
-# Load PWN 3.0 mapping (ili_id -> synset_id)
+d = sys.argv[1]
 pwn = {}
-with open('bin/cili_pwn_map.tab') as f:
+with open(f'{d}/cili_pwn_map.tab') as f:
     for line in f:
         parts = line.strip().split('\t')
         if len(parts) == 2:
             pwn[parts[0]] = parts[1]
-# Read definitions and merge
-with open('bin/cili_defs.tsv') as fin, open('bin/cili.tsv', 'w', newline='') as fout:
+with open(f'{d}/cili_defs.tsv') as fin, open(f'{d}/cili.tsv', 'w', newline='') as fout:
     reader = csv.DictReader(fin, delimiter='\t')
     writer = csv.writer(fout, delimiter='\t')
     writer.writerow(['ili_id', 'status', 'superseded_by', 'origin', 'definition'])
     for row in reader:
         ili = row['ILI']
         if ili in pwn:
-            origin = f'pwn-3.0:{pwn[ili]}'
-            writer.writerow([ili, '1', '', origin, row['Definition']])
-"
-        rm -f bin/cili_defs.tsv bin/cili_pwn_map.tab
+            writer.writerow([ili, '1', '', f'pwn-3.0:{pwn[ili]}', row['Definition']])
+" "$DATA_DIR/bin"
+        rm -f "$DATA_DIR/bin/cili_defs.tsv" "$DATA_DIR/bin/cili_pwn_map.tab"
     else
         echo "  CILI already present, skipping."
     fi
@@ -141,7 +168,7 @@ with open('bin/cili_defs.tsv') as fin, open('bin/cili.tsv', 'w', newline='') as 
     while IFS=$'\t' read -r stem url; do
         if [[ "$url" == *.xml.gz ]] || [[ "$url" == *.xml.xz ]] || [[ "$url" == *.xml ]]; then
             # Direct XML (possibly compressed) — download straight to bin/raw_wns/
-            fname="bin/raw_wns/$(basename "$url")"
+            fname="$DATA_DIR/bin/raw_wns/$(basename "$url")"
             if [ ! -f "$fname" ]; then
                 echo "  Downloading $(basename "$url")..."
                 curl -fSL -o "$fname" "$url"
@@ -150,8 +177,8 @@ with open('bin/cili_defs.tsv') as fin, open('bin/cili.tsv', 'w', newline='') as 
             fi
         else
             # Archive — extract and copy XMLs flat into bin/raw_wns/
-            if ! compgen -G "bin/raw_wns/${stem}*.xml" > /dev/null 2>&1 && \
-               ! compgen -G "bin/raw_wns/*/${stem}*/*.xml" > /dev/null 2>&1; then
+            if ! compgen -G "$DATA_DIR/bin/raw_wns/${stem}*.xml" > /dev/null 2>&1 && \
+               ! compgen -G "$DATA_DIR/bin/raw_wns/*/${stem}*/*.xml" > /dev/null 2>&1; then
                 download_standalone "$stem" "$url"
             else
                 echo "  $stem already present, skipping."
@@ -160,8 +187,9 @@ with open('bin/cili_defs.tsv') as fin, open('bin/cili.tsv', 'w', newline='') as 
     done < <(get_wordnet_urls)
 
     # ODEnet archive uses 'deWordNet.xml' internally; rename to match stem.
-    [ -f bin/raw_wns/deWordNet.xml ] && [ ! -f bin/raw_wns/odenet.xml ] && \
-        mv bin/raw_wns/deWordNet.xml bin/raw_wns/odenet.xml || true
+    [[ -f "$DATA_DIR/bin/raw_wns/deWordNet.xml" ]] && \
+        [[ ! -f "$DATA_DIR/bin/raw_wns/odenet.xml" ]] && \
+        mv "$DATA_DIR/bin/raw_wns/deWordNet.xml" "$DATA_DIR/bin/raw_wns/odenet.xml" || true
 
     echo "  Downloads complete."
     echo
@@ -173,17 +201,13 @@ fi
 if $DO_BUILD; then
     echo "=== Setting up Python environment ==="
 
-    # Build the extras list for uv sync
     EXTRAS=()
     if $WITH_GLOSSTAG; then EXTRAS+=(--extra glosstag); fi
     if $WITH_TRANSLATE; then EXTRAS+=(--extra translate); fi
 
     uv sync ${EXTRAS[@]+"${EXTRAS[@]}"}
 
-    # Download NLTK data (wordnet lemmatizer needs this)
     uv run python -c "import nltk; nltk.download('wordnet', quiet=True); nltk.download('omw-1.4', quiet=True)"
-
-    # Install Playwright browser binaries if not already present
     uv run playwright install chromium
 
     echo
@@ -195,68 +219,70 @@ fi
 if $DO_BUILD; then
 
     echo "=== Step 1: Extract CILI ==="
-    uv run python conversion_scripts/1_extract_cili.py
+    run_pipeline 1_extract_cili.py
     echo
 
     echo "=== Step 2: Convert wordnets ==="
-    uv run python conversion_scripts/2_batch_convert_lmfs.py
+    run_pipeline 2_batch_convert_lmfs.py
     echo
 
     if $WITH_GLOSSTAG; then
         echo "=== Step 3: Extract GlossTag ==="
-        uv run python conversion_scripts/3_extract_glosstag.py
+        run_pipeline 3_extract_glosstag.py
         echo
 
         echo "=== Step 4: Add GlossTag to CILI ==="
-        uv run python conversion_scripts/4_add_glosstag_to_cili.py
+        run_pipeline 4_add_glosstag_to_cili.py
         echo
     fi
 
     if $WITH_TRANSLATE; then
         echo "=== Step 5: Translate definitions ==="
-        uv run python conversion_scripts/5_translate_defns.py
+        run_pipeline 5_translate_defns.py
         echo
     fi
 
     echo "=== Step 6: Synthesise ==="
-    uv run python conversion_scripts/6_synthesise.py
+    run_pipeline 6_synthesise.py
     echo
 
     echo "=== Step 9: Populate language names ==="
-    uv run python conversion_scripts/9_lang_codes.py
+    run_pipeline 9_lang_codes.py
     echo
 
     echo "=== Step 11: Add ARASAAC pictogram IDs ==="
-    uv run python conversion_scripts/11_add_arasaac.py
+    run_pipeline 11_add_arasaac.py
     echo
 
     if $WITH_XML; then
         echo "=== Step 7: Generate and validate XML ==="
-        uv run python conversion_scripts/7_validate_and_export.py
+        run_pipeline 7_validate_and_export.py
         echo
     fi
 
     if $DO_TESTS; then
         echo "=== Tests ==="
         uv run pytest tests/ -v
+        echo
     fi
-    echo
 
     echo "=== Step 12: Compress databases ==="
-    gzip -k -9 -f web/cygnet.db
-    gzip -k -9 -f web/provenance.db
+    gzip -k -9 -f "$DATA_DIR/web/cygnet.db"
+    gzip -k -9 -f "$DATA_DIR/web/provenance.db"
     echo
 
     echo "=== Build complete! ==="
     echo "Output:"
-    echo "  web/cygnet.db         - SQLite database for web interface"
-    echo "  web/cygnet.db.gz      - compressed"
-    echo "  web/provenance.db     - provenance database"
-    echo "  web/provenance.db.gz  - compressed"
+    echo "  $DATA_DIR/web/cygnet.db         - SQLite database for web interface"
+    echo "  $DATA_DIR/web/cygnet.db.gz      - compressed"
+    echo "  $DATA_DIR/web/provenance.db     - provenance database"
+    echo "  $DATA_DIR/web/provenance.db.gz  - compressed"
     if $WITH_XML; then
-        echo "  cygnet.xml            - full merged resource (with provenance)"
-        echo "  cygnet_small.xml      - without provenance metadata"
+        echo "  $DATA_DIR/cygnet.xml            - full merged resource (with provenance)"
+        echo "  $DATA_DIR/cygnet_small.xml      - without provenance metadata"
     fi
     echo
-    echo "You can test with: bash run.sh"
+    if [[ "$DATA_DIR" == "$PROJECT_DIR" ]]; then
+        echo "You can test with: bash run.sh"
+    fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,12 @@ if [[ -n "$WORK_DIR" ]]; then
     fi
     # 7_validate_and_export.py reads cygnet.xsd from cwd; copy it into DATA_DIR.
     cp "$PROJECT_DIR/cygnet.xsd" "$DATA_DIR/cygnet.xsd"
+    # 11_add_arasaac.py uses the pre-built ILI mapping from the cygnet repo
+    # rather than re-downloading and re-building it from scratch.
+    if [[ -f "$PROJECT_DIR/data/araasac-ili.json" ]]; then
+        mkdir -p "$DATA_DIR/data"
+        cp "$PROJECT_DIR/data/araasac-ili.json" "$DATA_DIR/data/araasac-ili.json"
+    fi
 else
     DATA_DIR="$PROJECT_DIR"
 fi

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,11 @@ WORK_DIR=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --work-dir)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "Error: --work-dir requires a directory argument." >&2
+                echo "Run with --help for usage." >&2
+                exit 1
+            fi
             WORK_DIR="$2"
             shift 2
             ;;
@@ -94,13 +99,15 @@ run_pipeline() {
 download_standalone() {
     local name="$1" url="$2"
     echo "  Downloading $name..."
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' RETURN
-    curl -fSL -o "$tmpdir/archive" "$url"
-    tar xf "$tmpdir/archive" -C "$tmpdir/"
-    find "$tmpdir" \( -name '*.xml' -o -name '*.xml.gz' -o -name '*.xml.xz' \) \
-        -exec cp -n {} "$DATA_DIR/bin/raw_wns/" \;
+    (
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        trap 'rm -rf "$tmpdir"' EXIT
+        curl -fSL -o "$tmpdir/archive" "$url"
+        tar xf "$tmpdir/archive" -C "$tmpdir/"
+        find "$tmpdir" \( -name '*.xml' -o -name '*.xml.gz' -o -name '*.xml.xz' \) \
+            -exec cp -n {} "$DATA_DIR/bin/raw_wns/" \;
+    )
 }
 
 # Parse wordnets.toml and emit "stem<TAB>url" lines (no tomllib dependency needed).

--- a/cyg/converters.py
+++ b/cyg/converters.py
@@ -557,8 +557,10 @@ class WordNetToCygnetConverter:
             # 1. spaCy lemmatization.  Some models (e.g. Korean) output
             # morpheme-split lemmas like "크+다"; add the collapsed form and
             # the leading stem so that "크+다" and "크+ㄴ" can match via "크".
+            # Some multilingual models return "" as the lemma — skip these.
             lemma = token.lemma_
-            forms.add(lemma)
+            if lemma:
+                forms.add(lemma)
             if '+' in lemma:
                 forms.add(lemma.replace('+', ''))
                 forms.add(lemma.split('+')[0])
@@ -589,10 +591,17 @@ class WordNetToCygnetConverter:
         for token in doc:
             token_lower = token.text.lower()
             token_lemma = token.lemma_.lower()
-            token_candidates = {token_lower, token_lemma}
-            if '+' in token_lemma:  # Korean morpheme-split lemmas
-                token_candidates.add(token_lemma.replace('+', ''))
-                token_candidates.add(token_lemma.split('+')[0])
+            token_candidates = {token_lower}
+            if token_lemma:  # skip empty lemmas from multilingual models
+                token_candidates.add(token_lemma)
+                if '+' in token_lemma:  # Korean morpheme-split lemmas
+                    token_candidates.add(token_lemma.replace('+', ''))
+                    token_candidates.add(token_lemma.split('+')[0])
+            if self.nltk_lemmatizer is not None:
+                for pos in ['n', 'v', 'a', 'r']:
+                    token_candidates.add(
+                        self.nltk_lemmatizer.lemmatize(token_lower, pos=pos)
+                    )
             if token_candidates & wordform_forms:
                 return token_lower
         return None
@@ -628,10 +637,17 @@ class WordNetToCygnetConverter:
 
                 token_lower = token.text.lower()
                 token_lemma = token.lemma_.lower()
-                token_candidates = {token_lower, token_lemma}
-                if '+' in token_lemma:  # Korean morpheme-split lemmas
-                    token_candidates.add(token_lemma.replace('+', ''))
-                    token_candidates.add(token_lemma.split('+')[0])
+                token_candidates = {token_lower}
+                if token_lemma:  # skip empty lemmas from multilingual models
+                    token_candidates.add(token_lemma)
+                    if '+' in token_lemma:  # Korean morpheme-split lemmas
+                        token_candidates.add(token_lemma.replace('+', ''))
+                        token_candidates.add(token_lemma.split('+')[0])
+                if self.nltk_lemmatizer is not None:
+                    for pos in ['n', 'v', 'a', 'r']:
+                        token_candidates.add(
+                            self.nltk_lemmatizer.lemmatize(token_lower, pos=pos)
+                        )
 
                 if target_forms & token_candidates:
                     matched_token_indices.append(j)

--- a/cyg/converters.py
+++ b/cyg/converters.py
@@ -584,25 +584,30 @@ class WordNetToCygnetConverter:
         self.form_cache[word_lower] = forms
         return forms
 
+    def _token_candidates(self, token_lower: str, token_lemma: str) -> set[str]:
+        """Build the set of normalised forms for a single spaCy token.
+
+        Handles empty lemmas (multilingual fallback model), Korean morpheme-split
+        lemmas, and NLTK lemmatisation as a fallback for morphologically rich forms.
+        """
+        candidates = {token_lower}
+        if token_lemma:
+            candidates.add(token_lemma)
+            if '+' in token_lemma:
+                candidates.add(token_lemma.replace('+', ''))
+                candidates.add(token_lemma.split('+')[0])
+        if self.nltk_lemmatizer is not None:
+            for pos in ['n', 'v', 'a', 'r']:
+                candidates.add(self.nltk_lemmatizer.lemmatize(token_lower, pos=pos))
+        return candidates
+
     def _match_single_word(self, wordform: str, text: str) -> str | None:
         """Match a single word using morphological form matching."""
         wordform_forms = self._get_all_forms(wordform)
         doc = self._get_doc(text)
         for token in doc:
             token_lower = token.text.lower()
-            token_lemma = token.lemma_.lower()
-            token_candidates = {token_lower}
-            if token_lemma:  # skip empty lemmas from multilingual models
-                token_candidates.add(token_lemma)
-                if '+' in token_lemma:  # Korean morpheme-split lemmas
-                    token_candidates.add(token_lemma.replace('+', ''))
-                    token_candidates.add(token_lemma.split('+')[0])
-            if self.nltk_lemmatizer is not None:
-                for pos in ['n', 'v', 'a', 'r']:
-                    token_candidates.add(
-                        self.nltk_lemmatizer.lemmatize(token_lower, pos=pos)
-                    )
-            if token_candidates & wordform_forms:
+            if self._token_candidates(token_lower, token.lemma_.lower()) & wordform_forms:
                 return token_lower
         return None
 
@@ -636,20 +641,7 @@ class WordNetToCygnetConverter:
                 target_forms = content_word_forms[content_match_idx]
 
                 token_lower = token.text.lower()
-                token_lemma = token.lemma_.lower()
-                token_candidates = {token_lower}
-                if token_lemma:  # skip empty lemmas from multilingual models
-                    token_candidates.add(token_lemma)
-                    if '+' in token_lemma:  # Korean morpheme-split lemmas
-                        token_candidates.add(token_lemma.replace('+', ''))
-                        token_candidates.add(token_lemma.split('+')[0])
-                if self.nltk_lemmatizer is not None:
-                    for pos in ['n', 'v', 'a', 'r']:
-                        token_candidates.add(
-                            self.nltk_lemmatizer.lemmatize(token_lower, pos=pos)
-                        )
-
-                if target_forms & token_candidates:
+                if self._token_candidates(token_lower, token.lemma_.lower()) & target_forms:
                     matched_token_indices.append(j)
                     content_match_idx += 1
 

--- a/cyg/converters.py
+++ b/cyg/converters.py
@@ -299,6 +299,7 @@ class WordNetToCygnetConverter:
         # Caching for performance
         self.doc_cache: dict[str, any] = {}  # spaCy document cache
         self.form_cache: dict[str, set[str]] = {}  # morphological forms cache
+        self.nltk_cache: dict[str, frozenset[str]] = {}  # NLTK lemmas per token
 
         # Build reverse mapping: concept_id -> list of sense_ids
         self.concept_to_senses: dict[str, list[str]] = defaultdict(list)
@@ -597,8 +598,12 @@ class WordNetToCygnetConverter:
                 candidates.add(token_lemma.replace('+', ''))
                 candidates.add(token_lemma.split('+')[0])
         if self.nltk_lemmatizer is not None:
-            for pos in ['n', 'v', 'a', 'r']:
-                candidates.add(self.nltk_lemmatizer.lemmatize(token_lower, pos=pos))
+            if token_lower not in self.nltk_cache:
+                self.nltk_cache[token_lower] = frozenset(
+                    self.nltk_lemmatizer.lemmatize(token_lower, pos=p)
+                    for p in ['n', 'v', 'a', 'r']
+                )
+            candidates |= self.nltk_cache[token_lower]
         return candidates
 
     def _match_single_word(self, wordform: str, text: str) -> str | None:

--- a/notes/local.json.example
+++ b/notes/local.json.example
@@ -1,0 +1,29 @@
+{
+  "_comment": "Copy this file to local.json and edit as needed. Omit any fields you don't want to override.",
+
+  "title": "My Wordnet",
+  "tagline": "A multilingual lexical resource",
+  "icon": "📚",
+
+  "db": "myproject.db.gz",
+  "provenanceDb": "myproject-provenance.db.gz",
+
+  "logo": {
+    "src": "mylogo.svg",
+    "url": "https://myproject.org",
+    "alt": "My Project"
+  },
+
+  "header": "<strong>Preview build</strong> — data updated 2025-01-01.",
+
+  "footer": "Built by the <a href='https://mylab.org' style='text-decoration:underline'>My Lab</a> team.",
+
+  "about": {
+    "intro": "<p>My Wordnet is a multilingual lexical database covering X languages.</p><p>Developed by Jane Doe. Source code on <a href='https://github.com/example/mywordnet' style='text-decoration:underline'>GitHub</a>.</p>",
+    "citation": "If you use My Wordnet, please cite Doe (2025) as well as the individual wordnets whose data you use."
+  },
+
+  "publications": [
+    "Jane Doe (2025). My Wordnet: A new multilingual resource. In <em>Proceedings of GWC 2025</em>."
+  ]
+}

--- a/notes/local.json.example
+++ b/notes/local.json.example
@@ -25,7 +25,8 @@
   "logo": {
     "src": "mylogo.svg",
     "url": "https://myproject.org",
-    "alt": "My Project"
+    "alt": "My Project",
+    "name": "MWN"
   },
 
   "header": "<strong>Preview build</strong> — data updated 2025-01-01.",

--- a/notes/local.json.example
+++ b/notes/local.json.example
@@ -2,11 +2,25 @@
   "_comment": "Copy this file to local.json and edit as needed. Omit any fields you don't want to override.",
 
   "title": "My Wordnet",
+  "name": "MWN",
   "tagline": "A multilingual lexical resource",
   "icon": "📚",
 
   "db": "myproject.db.gz",
   "provenanceDb": "myproject-provenance.db.gz",
+
+  "databases": [
+    {
+      "filename": "myproject.db.gz",
+      "url": "https://github.com/example/mywordnet/releases/latest/download/myproject.db.gz",
+      "description": "The main lexical database, containing synsets, entries, senses, definitions, and examples."
+    },
+    {
+      "filename": "myproject-provenance.db.gz",
+      "url": "https://github.com/example/mywordnet/releases/latest/download/myproject-provenance.db.gz",
+      "description": "Provenance records tracing every data point back to its source and original identifier."
+    }
+  ],
 
   "logo": {
     "src": "mylogo.svg",
@@ -20,7 +34,8 @@
 
   "about": {
     "intro": "<p>My Wordnet is a multilingual lexical database covering X languages.</p><p>Developed by Jane Doe. Source code on <a href='https://github.com/example/mywordnet' style='text-decoration:underline'>GitHub</a>.</p>",
-    "citation": "If you use My Wordnet, please cite Doe (2025) as well as the individual wordnets whose data you use."
+    "citation": "If you use My Wordnet, please cite Doe (2025) as well as the individual wordnets whose data you use.",
+    "languageData": "My Wordnet covers X languages drawn from Y resources — see the Wordnets tab for details."
   },
 
   "publications": [

--- a/notes/local.json.example
+++ b/notes/local.json.example
@@ -9,6 +9,9 @@
   "db": "myproject.db.gz",
   "provenanceDb": "myproject-provenance.db.gz",
 
+  "searchLanguage": "kaw",
+  "displayLanguage": "kaw",
+
   "databases": [
     {
       "filename": "myproject.db.gz",

--- a/notes/local.json.example
+++ b/notes/local.json.example
@@ -6,24 +6,21 @@
   "tagline": "A multilingual lexical resource",
   "icon": "📚",
 
-  "db": "myproject.db.gz",
-  "provenanceDb": "myproject-provenance.db.gz",
-
   "searchLanguage": "kaw",
   "displayLanguage": "kaw",
 
-  "databases": [
-    {
+  "databases": {
+    "main": {
       "filename": "myproject.db.gz",
       "url": "https://github.com/example/mywordnet/releases/latest/download/myproject.db.gz",
       "description": "The main lexical database, containing synsets, entries, senses, definitions, and examples."
     },
-    {
+    "provenance": {
       "filename": "myproject-provenance.db.gz",
       "url": "https://github.com/example/mywordnet/releases/latest/download/myproject-provenance.db.gz",
       "description": "Provenance records tracing every data point back to its source and original identifier."
     }
-  ],
+  },
 
   "logo": {
     "src": "mylogo.svg",

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-cd "$(dirname "$0")/web"
+#!/usr/bin/env bash
+# Usage: run.sh [dir]  — serves dir (default: web/) in a browser.
+cd "${1:-$(dirname "$0")/web}"
 python3 - <<'EOF'
 import http.server, socket, webbrowser
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,3 +242,29 @@ def http_server_with_config(test_db_dir, tmp_path_factory):
     server, url = _start_server(str(config_dir))
     yield url
     server.shutdown()
+
+
+@pytest.fixture(scope='session')
+def http_server_with_branding(test_db_dir, tmp_path_factory):
+    """HTTP server serving a local.json with full header branding.
+
+    Sets title='TestWN', icon='🧪', name='TWN', and a custom logo with
+    name='TWN' so tests can verify both header sides are customisable.
+    """
+    branding_dir = tmp_path_factory.mktemp('serve_branding')
+    for f in test_db_dir.iterdir():
+        shutil.copy(f, branding_dir / f.name)
+    (branding_dir / 'local.json').write_text(json.dumps({
+        'title': 'TestWN',
+        'icon': '🧪',
+        'name': 'TWN',
+        'logo': {
+            'src': 'omw-logo.svg',
+            'url': 'https://omwn.org',
+            'alt': 'Test Wordnet',
+            'name': 'TWN',
+        },
+    }))
+    server, url = _start_server(str(branding_dir))
+    yield url
+    server.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,10 +194,6 @@ def valid_ili() -> str:
 # HTTP server fixture (used by UI tests)
 # ---------------------------------------------------------------------------
 
-_UI_PORT = 9877
-_UI_PORT_CONFIG = 9878
-
-
 def _make_handler(directory: str):
     class Handler(SimpleHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
@@ -214,16 +210,19 @@ def _make_handler(directory: str):
     return Handler
 
 
+def _start_server(directory: str) -> tuple[HTTPServer, str]:
+    """Bind an HTTPServer to an ephemeral port; return (server, base_url)."""
+    server = HTTPServer(('localhost', 0), _make_handler(directory))
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f'http://localhost:{port}'
+
+
 @pytest.fixture(scope='session')
 def http_server(test_db_dir):
     """Session-scoped HTTP server serving the test DB directory."""
-    server = HTTPServer(
-        ('localhost', _UI_PORT),
-        _make_handler(str(test_db_dir)),
-    )
-    t = threading.Thread(target=server.serve_forever, daemon=True)
-    t.start()
-    yield f'http://localhost:{_UI_PORT}'
+    server, url = _start_server(str(test_db_dir))
+    yield url
     server.shutdown()
 
 
@@ -240,11 +239,6 @@ def http_server_with_config(test_db_dir, tmp_path_factory):
     (config_dir / 'local.json').write_text(
         json.dumps({'searchLanguage': 'fr', 'displayLanguage': 'fr'})
     )
-    server = HTTPServer(
-        ('localhost', _UI_PORT_CONFIG),
-        _make_handler(str(config_dir)),
-    )
-    t = threading.Thread(target=server.serve_forever, daemon=True)
-    t.start()
-    yield f'http://localhost:{_UI_PORT_CONFIG}'
+    server, url = _start_server(str(config_dir))
+    yield url
     server.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures and test-data helpers for the Cygnet test suite."""
 
+import json
 import shutil
 import subprocess
 import textwrap
@@ -194,6 +195,7 @@ def valid_ili() -> str:
 # ---------------------------------------------------------------------------
 
 _UI_PORT = 9877
+_UI_PORT_CONFIG = 9878
 
 
 def _make_handler(directory: str):
@@ -222,4 +224,27 @@ def http_server(test_db_dir):
     t = threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
     yield f'http://localhost:{_UI_PORT}'
+    server.shutdown()
+
+
+@pytest.fixture(scope='session')
+def http_server_with_config(test_db_dir, tmp_path_factory):
+    """HTTP server like http_server but also serves a local.json config file.
+
+    The config sets searchLanguage='fr' and displayLanguage='fr' so tests
+    can verify that local.json seeds the correct UI defaults on page load.
+    """
+    config_dir = tmp_path_factory.mktemp('serve_config')
+    for f in test_db_dir.iterdir():
+        shutil.copy(f, config_dir / f.name)
+    (config_dir / 'local.json').write_text(
+        json.dumps({'searchLanguage': 'fr', 'displayLanguage': 'fr'})
+    )
+    server = HTTPServer(
+        ('localhost', _UI_PORT_CONFIG),
+        _make_handler(str(config_dir)),
+    )
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f'http://localhost:{_UI_PORT_CONFIG}'
     server.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,11 @@ from cyg.merge import MergeBuilder
 
 _WORDNETS_DIR = Path(__file__).parent / 'wordnets'
 
+_DEFAULT_DATABASES = {
+    'main':       {'filename': 'cygnet.db.gz'},
+    'provenance': {'filename': 'provenance.db.gz'},
+}
+
 
 # ---------------------------------------------------------------------------
 # Shared XML helpers
@@ -181,6 +186,17 @@ def test_db_dir(tmp_path_factory):
     shutil.copy(web_dir / 'relations.json', serve_dir / 'relations.json')
     shutil.copy(db_path.with_suffix('.db.gz'), serve_dir / 'cygnet.db.gz')
     shutil.copy(prov_path.with_suffix('.db.gz'), serve_dir / 'provenance.db.gz')
+    (serve_dir / 'local.json').write_text(json.dumps({
+        'title': 'Cygnet',
+        'icon': '🦢',
+        'databases': _DEFAULT_DATABASES,
+        'about': {
+            'citation': 'Please cite <a href="#">Test Author (2025)</a> when using this resource.',
+        },
+        'publications': [
+            'Test Author (2025). A test paper. In <em>Test Proceedings</em>.',
+        ],
+    }))
     return serve_dir
 
 
@@ -235,10 +251,13 @@ def http_server_with_config(test_db_dir, tmp_path_factory):
     """
     config_dir = tmp_path_factory.mktemp('serve_config')
     for f in test_db_dir.iterdir():
-        shutil.copy(f, config_dir / f.name)
-    (config_dir / 'local.json').write_text(
-        json.dumps({'searchLanguage': 'fr', 'displayLanguage': 'fr'})
-    )
+        if f.name != 'local.json':
+            shutil.copy(f, config_dir / f.name)
+    (config_dir / 'local.json').write_text(json.dumps({
+        'searchLanguage': 'fr',
+        'displayLanguage': 'fr',
+        'databases': _DEFAULT_DATABASES,
+    }))
     server, url = _start_server(str(config_dir))
     yield url
     server.shutdown()
@@ -253,7 +272,8 @@ def http_server_with_branding(test_db_dir, tmp_path_factory):
     """
     branding_dir = tmp_path_factory.mktemp('serve_branding')
     for f in test_db_dir.iterdir():
-        shutil.copy(f, branding_dir / f.name)
+        if f.name != 'local.json':
+            shutil.copy(f, branding_dir / f.name)
     (branding_dir / 'local.json').write_text(json.dumps({
         'title': 'TestWN',
         'icon': '🧪',
@@ -264,6 +284,7 @@ def http_server_with_branding(test_db_dir, tmp_path_factory):
             'alt': 'Test Wordnet',
             'name': 'TWN',
         },
+        'databases': _DEFAULT_DATABASES,
     }))
     server, url = _start_server(str(branding_dir))
     yield url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,7 @@ def http_server_with_branding(test_db_dir, tmp_path_factory):
         'title': 'TestWN',
         'icon': '🧪',
         'name': 'TWN',
+        'url': 'https://example.org/testwn',
         'logo': {
             'src': 'omw-logo.svg',
             'url': 'https://omwn.org',

--- a/tests/test_example_matching.py
+++ b/tests/test_example_matching.py
@@ -27,6 +27,7 @@ def _make_converter(lang: str) -> WordNetToCygnetConverter:
     conv.lexicon_language = lang
     conv.doc_cache = {}
     conv.form_cache = {}
+    conv.nltk_cache = {}
     conv.nltk_lemmatizer = None
     try:
         import nltk

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -497,11 +497,10 @@ class TestArasaac:
 
 
 class TestPublications:
-    def test_publications_tab_shows_main_papers(self, page_ready: Page):
-        """Publications tab lists the Cygnet and OMW papers."""
+    def test_publications_tab_shows_configured_paper(self, page_ready: Page):
+        """Publications tab lists papers from local.json publications array."""
         page_ready.locator('button', has_text='Publications').click()
-        expect(page_ready.locator('text=Maudslay')).to_be_visible(timeout=5_000)
-        expect(page_ready.locator('text=Bond').first).to_be_visible()
+        expect(page_ready.locator('text=Test Author')).to_be_visible(timeout=5_000)
 
     def test_publications_tab_shows_wordnet_citations_header(self, page_ready: Page):
         """Publications tab has a Wordnet Citations section."""
@@ -530,11 +529,10 @@ class TestPublications:
         ).to_be_visible()
 
     def test_about_tab_citation_section(self, page_ready: Page):
-        """About tab has a Citation section with links to key papers."""
+        """About tab has a Citation section with content from local.json."""
         page_ready.locator('button', has_text='About').click()
         expect(page_ready.locator('text=Citation')).to_be_visible(timeout=5_000)
-        expect(page_ready.locator('button', has_text='Maudslay')).to_be_visible()
-        expect(page_ready.locator('button', has_text='Bond & Foster')).to_be_visible()
+        expect(page_ready.locator('text=Test Author')).to_be_visible()
 
     def test_about_tab_download_section(self, page_ready: Page):
         """About tab has a Download section with database links."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -910,3 +910,9 @@ class TestHeaderCustomization:
     def test_custom_logo_name_in_header(self, page_branding: Page):
         """local.json logo.name appears to the left of the logo image."""
         expect(page_branding.locator('header span', has_text='TWN').first).to_be_visible()
+
+    def test_custom_title_url_in_header(self, page_branding: Page):
+        """local.json url makes the title an external link."""
+        link = page_branding.locator('header a', has_text='TestWN')
+        expect(link).to_be_visible()
+        assert link.get_attribute('href') == 'https://example.org/testwn'

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -851,3 +851,38 @@ class TestVariantFormSearch:
         expect(
             page_ready.locator('.sense-box').filter(has_text='Variants')
         ).not_to_be_visible()
+
+
+class TestLocalJsonConfig:
+    """local.json searchLanguage/displayLanguage seed the correct UI defaults."""
+
+    @pytest.fixture()
+    def page_with_config(self, page: Page, http_server_with_config):
+        """Open the app served with a local.json setting fr as search/display language."""
+        page.goto(http_server_with_config)
+        page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
+        return page
+
+    def test_search_language_filters_to_configured_language(
+        self, page_with_config: Page
+    ):
+        """searchLanguage:'fr' means searching i3 returns only the French sense."""
+        _search(page_with_config, 'i3')
+        # With searchLanguage=fr the filter is pre-set to French, so only chien appears
+        assert _result_count(page_with_config) == 1
+        assert _language_count(page_with_config) == 1
+        expect(page_with_config.locator('.sense-box', has_text='chien')).to_be_visible()
+
+    def test_url_param_overrides_search_language(
+        self, page: Page, http_server_with_config
+    ):
+        """A search_lang URL param overrides the local.json searchLanguage default."""
+        page.goto(http_server_with_config + '#/search?q=i3&search_lang=en')
+        page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
+        page.locator('span.text-sm.text-gray-500').filter(
+            has_text='across'
+        ).or_(
+            page.locator('text=No results found')
+        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        assert _result_count(page) == 1
+        expect(page.locator('.sense-box', has_text='dog')).to_be_visible()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -886,3 +886,17 @@ class TestLocalJsonConfig:
         ).wait_for(timeout=_SEARCH_TIMEOUT)
         assert _result_count(page) == 1
         expect(page.locator('.sense-box', has_text='dog')).to_be_visible()
+
+    def test_url_without_search_lang_respects_default(
+        self, page: Page, http_server_with_config
+    ):
+        """A URL without search_lang still uses the local.json searchLanguage default."""
+        page.goto(http_server_with_config + '#/search?q=i3')
+        page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
+        page.locator('span.text-sm.text-gray-500').filter(
+            has_text='across'
+        ).or_(
+            page.locator('text=No results found')
+        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        assert _result_count(page) == 1
+        expect(page.locator('.sense-box', has_text='chien')).to_be_visible()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -888,3 +888,27 @@ class TestLocalJsonConfig:
         _wait_for_results(page)
         assert _result_count(page) == 1
         expect(page.locator('.sense-box', has_text='chien')).to_be_visible()
+
+
+# ---------------------------------------------------------------------------
+# Header customisation via local.json
+# ---------------------------------------------------------------------------
+
+class TestHeaderCustomization:
+    @pytest.fixture()
+    def page_branding(self, page: Page, http_server_with_branding):
+        page.goto(http_server_with_branding)
+        page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
+        return page
+
+    def test_custom_title_in_header(self, page_branding: Page):
+        """local.json title replaces 'Cygnet' in the header."""
+        expect(page_branding.locator('header h1', has_text='TestWN')).to_be_visible()
+
+    def test_custom_icon_in_header(self, page_branding: Page):
+        """local.json icon replaces the default swan emoji in the header."""
+        expect(page_branding.locator('header h1', has_text='🧪')).to_be_visible()
+
+    def test_custom_logo_name_in_header(self, page_branding: Page):
+        """local.json logo.name appears to the left of the logo image."""
+        expect(page_branding.locator('header span', has_text='TWN').first).to_be_visible()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -87,11 +87,11 @@ class TestPageLoad:
 
     def test_python_tab_absent(self, page_ready: Page):
         """Python tab was removed — should not appear in the nav."""
-        expect(page_ready.locator('button', has_text='Python')).not_to_be_visible()
+        expect(page_ready.locator('button', has_text='Python')).to_have_count(0)
 
     def test_data_tab_absent(self, page_ready: Page):
         """Data tab was merged into About — should not appear in the nav."""
-        expect(page_ready.locator('button', has_text='Data')).not_to_be_visible()
+        expect(page_ready.locator('button', has_text='Data')).to_have_count(0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -41,15 +41,19 @@ def page_ready(page: Page, http_server):
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _wait_for_results(page: Page) -> None:
+    """Wait until the results summary or 'No results found' banner appears."""
+    page.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
+        page.locator('text=No results found')
+    ).wait_for(timeout=_SEARCH_TIMEOUT)
+
+
 def _search(page: Page, term: str) -> None:
     """Type *term* into the search box, submit, and wait for results."""
     box = page.locator('input[placeholder*="word"]')
     box.fill(term)
     box.press('Enter')
-    # "1 result across …" uses singular; match on "across" which appears in both
-    page.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
-        page.locator('text=No results found')
-    ).wait_for(timeout=_SEARCH_TIMEOUT)
+    _wait_for_results(page)
 
 
 def _result_count(page: Page) -> int:
@@ -211,18 +215,14 @@ class TestDefinitionSearch:
         )
         en_label.click()
 
-        page_ready.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
-            page_ready.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page_ready)
 
         assert _result_count(page_ready) == 2
         assert _language_count(page_ready) == 1
 
         # Restore state — uncheck English filter
         en_label.click()
-        page_ready.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
-            page_ready.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page_ready)
 
 
 # ---------------------------------------------------------------------------
@@ -794,9 +794,7 @@ class TestSenseRelations:
         # Click the 'glowing' button in the sense relations section
         page_ready.locator('button', has_text='glowing').first.click()
         # App switches back to search view — wait for results summary
-        page_ready.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
-            page_ready.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page_ready)
         content = page_ready.content()
         assert 'glowing' in content
 
@@ -823,9 +821,7 @@ class TestSenseRelations:
         # Target sense loads async; locator retries until the '…' resolves to 'glowing'
         page_ready.locator('.sense-box button', has_text='glowing').first.click(timeout=_TEXT_VIEW_TIMEOUT * 2)
         # App switches to search view with glowing results
-        page_ready.locator('span.text-sm.text-gray-500').filter(has_text='across').or_(
-            page_ready.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page_ready)
         content = page_ready.content()
         assert 'glowing' in content
 
@@ -879,11 +875,7 @@ class TestLocalJsonConfig:
         """A search_lang URL param overrides the local.json searchLanguage default."""
         page.goto(http_server_with_config + '#/search?q=i3&search_lang=en')
         page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
-        page.locator('span.text-sm.text-gray-500').filter(
-            has_text='across'
-        ).or_(
-            page.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page)
         assert _result_count(page) == 1
         expect(page.locator('.sense-box', has_text='dog')).to_be_visible()
 
@@ -893,10 +885,6 @@ class TestLocalJsonConfig:
         """A URL without search_lang still uses the local.json searchLanguage default."""
         page.goto(http_server_with_config + '#/search?q=i3')
         page.wait_for_selector('input[placeholder*="word"]', timeout=_DB_LOAD_TIMEOUT)
-        page.locator('span.text-sm.text-gray-500').filter(
-            has_text='across'
-        ).or_(
-            page.locator('text=No results found')
-        ).wait_for(timeout=_SEARCH_TIMEOUT)
+        _wait_for_results(page)
         assert _result_count(page) == 1
         expect(page.locator('.sense-box', has_text='chien')).to_be_visible()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -82,7 +82,15 @@ class TestPageLoad:
 
     def test_nav_tabs_visible(self, page_ready: Page):
         expect(page_ready.locator('button', has_text='Browser')).to_be_visible()
-        expect(page_ready.locator('button', has_text='Data')).to_be_visible()
+        expect(page_ready.locator('button', has_text='About')).to_be_visible()
+
+    def test_python_tab_absent(self, page_ready: Page):
+        """Python tab was removed — should not appear in the nav."""
+        expect(page_ready.locator('button', has_text='Python')).not_to_be_visible()
+
+    def test_data_tab_absent(self, page_ready: Page):
+        """Data tab was merged into About — should not appear in the nav."""
+        expect(page_ready.locator('button', has_text='Data')).not_to_be_visible()
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +534,12 @@ class TestPublications:
         expect(page_ready.locator('text=Citation')).to_be_visible(timeout=5_000)
         expect(page_ready.locator('button', has_text='Maudslay')).to_be_visible()
         expect(page_ready.locator('button', has_text='Bond & Foster')).to_be_visible()
+
+    def test_about_tab_download_section(self, page_ready: Page):
+        """About tab has a Download section with database links."""
+        page_ready.locator('button', has_text='About').click()
+        expect(page_ready.get_by_role('heading', name='Download')).to_be_visible(timeout=5_000)
+        expect(page_ready.locator('a', has_text='.db.gz').first).to_be_visible()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,6 +6,7 @@ contents, so every assertion can be exact.
 Test DB contents (see conftest._UI_TEST_WORDNET):
   Synsets:  entity (i1), animal (i2), dog (i3), brightness (i4), dogfish (i5)
   Senses:   en:entity, en:animal, en:dog, en:brightness, en:dogfish, fr:chien
+  Variants: en:dog has variant form "doggo"
   Relations: dog→animal (hypernym), animal→entity (hypernym)
 
 Expected search results (exact/glob match on normalized_form):
@@ -827,3 +828,26 @@ class TestSenseRelations:
         ).wait_for(timeout=_SEARCH_TIMEOUT)
         content = page_ready.content()
         assert 'glowing' in content
+
+
+class TestVariantFormSearch:
+    """Searching by a variant form (rank > 0) auto-expands the variants section."""
+
+    def test_variant_search_shows_variants_expanded(self, page_ready: Page):
+        """Searching 'doggo' (a variant of 'dog') shows the Variants row without
+        requiring the user to click to expand the sense card."""
+        _search(page_ready, 'doggo')
+        page_ready.wait_for_selector('.sense-box', timeout=_SEARCH_TIMEOUT)
+        expect(
+            page_ready.locator('.sense-box').filter(has_text='Variants')
+        ).to_be_visible()
+
+    def test_lemma_search_does_not_auto_expand(self, page_ready: Page):
+        """Searching the canonical lemma 'dog' does NOT auto-expand the variants
+        section (variants are still accessible via the expand arrow)."""
+        _search(page_ready, 'dog')
+        page_ready.wait_for_selector('.sense-box', timeout=_SEARCH_TIMEOUT)
+        expect(page_ready.locator('.sense-box')).to_be_visible()
+        expect(
+            page_ready.locator('.sense-box').filter(has_text='Variants')
+        ).not_to_be_visible()

--- a/tests/wordnets/wn-en.xml
+++ b/tests/wordnets/wn-en.xml
@@ -94,6 +94,7 @@
   </Lexeme>
   <Lexeme id="lex.en.dog" language="en" grammatical_category="NOUN">
     <Wordform form="dog"/>
+    <Wordform form="doggo"/>
     <Provenance resource="wn-en" version="1.0" original_id="oewn-dog-n"/>
   </Lexeme>
   <Lexeme id="lex.en.brightness" language="en" grammatical_category="NOUN">

--- a/web/index.html
+++ b/web/index.html
@@ -1189,6 +1189,8 @@
                 setCurrentSearch(term);
                 setSenseFilter(null);
                 setSynonymsCollapsed({});
+                setActiveTab('browser');
+                setView('search');
                 performSearch(term, languageFilter, posFilter, null);
             };
 
@@ -1771,12 +1773,13 @@
                                                   </a>
                                                 : <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
                                           )
-                                        : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
+                                        : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80 flex items-center gap-2">
+                                              <span title="Open Multilingual Wordnet" className="text-3xl font-bold text-gray-800">OMW</span>
                                               <img src="omw-logo.svg" alt="Open Multilingual Wordnet" className="h-10" />
                                           </a>
                                 )}
                             </div>
-                            <nav className="flex items-end gap-3 mt-3 -mb-3">
+                            <nav className="flex items-end gap-3 mt-3 -mb-3 flex-wrap">
                                 {['browser', 'about', 'publications', 'wordnets'].map(tab => (
                                     <button key={tab}
                                         onClick={() => setActiveTab(tab)}
@@ -1787,7 +1790,25 @@
                                         }`}
                                     >{tab.charAt(0).toUpperCase() + tab.slice(1)}</button>
                                 ))}
-                                <div className="ml-auto relative pb-0" ref={settingsRef}>
+                                <div className="flex items-center gap-1.5 flex-grow min-w-48 pb-0.5">
+                                    <input type="text" value={searchTerm}
+                                        onChange={(e) => setSearchTerm(e.target.value)}
+                                        onKeyPress={handleKeyPress}
+                                        placeholder={dbReady ? "word, hot*, *ness, i1234, def:bright" : "Loading…"}
+                                        disabled={!dbReady}
+                                        className="flex-grow min-w-0 px-3 py-1.5 text-sm border border-gray-300 rounded disabled:opacity-50"
+                                    />
+                                    <div className="relative group flex-shrink-0">
+                                        <button className="w-6 h-6 rounded-full border border-gray-400 text-gray-500 text-xs font-bold hover:border-blue-500 hover:text-blue-500 flex items-center justify-center">ℹ</button>
+                                        <div className="absolute right-0 top-full mt-1 hidden group-hover:block bg-white border border-gray-200 rounded shadow-lg p-3 text-xs text-gray-700 z-30 w-64 space-y-1.5">
+                                            <div><span className="font-mono font-semibold">word</span> — exact match</div>
+                                            <div><span className="font-mono font-semibold">hot*</span> or <span className="font-mono font-semibold">*ness</span> — glob (<span className="font-mono">*</span> = any characters, <span className="font-mono">?</span> = one)</div>
+                                            <div><span className="font-mono font-semibold">i1234</span> or <span className="font-mono font-semibold">cili.i1234</span> — look up concept by ILI</div>
+                                            <div><span className="font-mono font-semibold">def:word</span> — search inside definitions</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="relative pb-0" ref={settingsRef}>
                                     <button onClick={() => setSettingsOpen(o => !o)}
                                         title="Settings"
                                         className={`px-3 py-2 rounded-t-lg border-b-2 transition-colors relative ${settingsOpen ? 'bg-gray-50 border-blue-500 text-blue-700' : 'border-transparent text-gray-600 hover:text-gray-900 hover:bg-gray-50'}`}>
@@ -1948,27 +1969,6 @@
                                 )}
                                 {view === 'search' && dbReady && (
                                     <div className="mb-8">
-                                        {!senseFilter && (
-                                            <div className="flex items-center gap-2">
-                                                <input type="text" value={searchTerm}
-                                                    onChange={(e) => setSearchTerm(e.target.value)}
-                                                    onKeyPress={handleKeyPress}
-                                                    placeholder="word, hot*, *ness, i1234, def:bright"
-                                                    className="flex-grow px-3 py-2 border border-gray-300 rounded"
-                                                />
-                                                <div className="relative group flex-shrink-0">
-                                                    <button className="w-6 h-6 rounded-full border border-gray-400 text-gray-500 text-xs font-bold hover:border-blue-500 hover:text-blue-500 flex items-center justify-center">ℹ</button>
-                                                    <div className="absolute right-0 top-full mt-1 hidden group-hover:block bg-white border border-gray-200 rounded shadow-lg p-3 text-xs text-gray-700 z-30 w-64 space-y-1.5">
-                                                        <div><span className="font-mono font-semibold">word</span> — exact match</div>
-                                                        <div><span className="font-mono font-semibold">hot*</span> or <span className="font-mono font-semibold">*ness</span> — glob (<span className="font-mono">*</span> = any characters, <span className="font-mono">?</span> = one)</div>
-                                                        <div><span className="font-mono font-semibold">i1234</span> or <span className="font-mono font-semibold">cili.i1234</span> — look up concept by ILI</div>
-                                                        <div><span className="font-mono font-semibold">def:word</span> — search inside definitions</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        )}
-
-
                                         {senseFilter && (
                                             <div className="mb-4 bg-blue-50 border border-blue-200 rounded p-4">
                                                 <div className="flex items-center justify-between">

--- a/web/index.html
+++ b/web/index.html
@@ -1766,10 +1766,16 @@
                         <div className="max-w-4xl mx-auto px-4 py-3">
                             <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-3">
-                                    <button onClick={handleLogoClick} className="text-left hover:opacity-80 flex items-center gap-1.5">
-                                        {siteConfig.icon && <h1 className="text-4xl -mt-0.5">{siteConfig.icon}</h1>}
-                                        {siteConfig.title && <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title}</h1>}
-                                    </button>
+                                    {siteConfig.url
+                                        ? <a href={siteConfig.url} target="_blank" rel="noopener noreferrer" className="hover:opacity-80 flex items-center gap-1.5">
+                                              {siteConfig.icon && <h1 className="text-4xl -mt-0.5">{siteConfig.icon}</h1>}
+                                              {siteConfig.title && <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title}</h1>}
+                                          </a>
+                                        : <button onClick={handleLogoClick} className="text-left hover:opacity-80 flex items-center gap-1.5">
+                                              {siteConfig.icon && <h1 className="text-4xl -mt-0.5">{siteConfig.icon}</h1>}
+                                              {siteConfig.title && <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title}</h1>}
+                                          </button>
+                                    }
                                 </div>
                                 {siteConfig.logo !== null && (
                                     siteConfig.logo

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,11 @@
         const _configPromise = fetch('local.json')
             .then(r => r.ok ? r.json() : {})
             .catch(() => ({}))
-            .then(cfg => { Object.assign(_siteConfig, cfg); });
+            .then(cfg => {
+                if (cfg && typeof cfg === 'object' && !Array.isArray(cfg)) {
+                    Object.assign(_siteConfig, cfg);
+                }
+            });
 
         // Build lookup tables from _relConfig once loaded.
         let RELATION_TO_SHORT = {};
@@ -2602,12 +2606,19 @@
                                                 The {siteName} databases are available for download below. Both are SQLite databases compressed with gzip.
                                             </p>
                                             <ul className="space-y-3 mb-3">
-                                                {dbs.map((db, i) => (
-                                                    <li key={i} className="text-sm text-gray-800">
-                                                        <a href={db.url} className="text-blue-600 hover:underline font-medium">{db.filename}</a>
-                                                        {db.description ? <>{' '}— {db.description}</> : null}
-                                                    </li>
-                                                ))}
+                                                {dbs.map((db, i) => {
+                                                    const href = db.url || db.filename || null;
+                                                    return (
+                                                        <li key={i} className="text-sm text-gray-800">
+                                                            {href ? (
+                                                                <a href={href} className="text-blue-600 hover:underline font-medium">{db.filename}</a>
+                                                            ) : (
+                                                                <span className="font-medium">{db.filename}</span>
+                                                            )}
+                                                            {db.description ? <>{' '}— {db.description}</> : null}
+                                                        </li>
+                                                    );
+                                                })}
                                             </ul>
                                             <p className="text-sm text-gray-600">
                                                 The individual wordnets that make up {siteName} are each available from their respective projects — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets</button> tab for the full list with links.

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,15 @@
         let _relConfig = {};
         let _relLang = 'en';
 
+        // ========== SITE CONFIG ==========
+        // Loaded from local.json at startup; falls back silently if absent.
+        // See notes/local.json.example for supported fields.
+        let _siteConfig = {};
+        const _configPromise = fetch('local.json')
+            .then(r => r.ok ? r.json() : {})
+            .catch(() => ({}))
+            .then(cfg => { Object.assign(_siteConfig, cfg); });
+
         // Build lookup tables from _relConfig once loaded.
         let RELATION_TO_SHORT = {};
         let _relColors = {};
@@ -547,6 +556,7 @@
             const [allResources, setAllResources] = useState([]);
             const [dbStats, setDbStats] = useState(null);
             const [wnSort, setWnSort] = useState({ col: null, asc: true });
+            const [siteConfig, setSiteConfig] = useState({});
             const [provenanceReady, setProvenanceReady] = useState(false);
             const [provLoading, setProvLoading] = useState(false);
             const [provError, setProvError] = useState(null);
@@ -636,10 +646,24 @@
                     .catch(e => console.warn('relations.json fetch failed:', e));
             }, []);
 
+            useEffect(() => {
+                _configPromise.then(() => {
+                    setSiteConfig({..._siteConfig});
+                    const { title, tagline, icon } = _siteConfig;
+                    if (title) document.title = title + (tagline ? ` — ${tagline}` : '');
+                    if (icon) {
+                        const link = document.querySelector("link[rel='icon']");
+                        if (link) link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${icon}</text></svg>`;
+                    }
+                });
+            }, []);
+
             // Initialize database
             useEffect(() => {
                 (async () => {
                     try {
+                        await _configPromise;
+                        const dbFile = _siteConfig.db || 'cygnet.db.gz';
                         setDbProgress('Loading sql.js...');
                         const SQL = await initSqlJs({
                             locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/${file}`
@@ -652,7 +676,7 @@
                             if (cached) {
                                 let stale = false;
                                 try {
-                                    const head = await fetch(DB_BASE + 'cygnet.db.gz', { method: 'HEAD' });
+                                    const head = await fetch(DB_BASE + dbFile, { method: 'HEAD' });
                                     const serverMtime = head.headers.get('last-modified') || head.headers.get('etag');
                                     const cachedMtime = await idbGet('db-mtime');
                                     if (serverMtime && serverMtime !== cachedMtime) stale = true;
@@ -672,7 +696,7 @@
                         if (!buf) {
                             // Fetch compressed database
                             setDbProgress('Downloading database...');
-                            const response = await fetch(DB_BASE + 'cygnet.db.gz');
+                            const response = await fetch(DB_BASE + dbFile);
                             if (!response.ok) throw new Error(`Failed to fetch database: ${response.status}`);
                             const serverMtime = response.headers.get('last-modified') || response.headers.get('etag') || '';
                             const compressedTotal = parseInt(response.headers.get('content-length') || '0');
@@ -916,7 +940,7 @@
                     }
 
                     if (!buf) {
-                        const response = await fetch(DB_BASE + 'provenance.db.gz');
+                        const response = await fetch(DB_BASE + (_siteConfig.provenanceDb || 'provenance.db.gz'));
                         if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
                         const ds = new DecompressionStream('gzip');
                         const reader = response.body.pipeThrough(ds).getReader();
@@ -1681,13 +1705,19 @@
                             <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-3">
                                     <button onClick={handleLogoClick} className="text-left hover:opacity-80 flex items-center gap-1.5">
-                                        <h1 className="text-4xl -mt-0.5">🦢</h1>
-                                        <h1 className="text-3xl font-bold text-gray-800"> Cygnet</h1>
+                                        <h1 className="text-4xl -mt-0.5">{siteConfig.icon || '🦢'}</h1>
+                                        <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title || 'Cygnet'}</h1>
                                     </button>
                                 </div>
-                                <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
-                                    <img src="omw-logo.svg" alt="Open Multilingual Wordnet" className="h-10" />
-                                </a>
+                                {siteConfig.logo !== null && (
+                                    siteConfig.logo
+                                        ? <a href={siteConfig.logo.url || '#'} target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
+                                              <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
+                                          </a>
+                                        : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
+                                              <img src="omw-logo.svg" alt="Open Multilingual Wordnet" className="h-10" />
+                                          </a>
+                                )}
                             </div>
                             <nav className="flex items-end gap-3 mt-3 -mb-3">
                                 {['browser', 'python', 'data', 'about', 'publications', 'wordnets'].map(tab => (
@@ -1819,6 +1849,13 @@
                             </nav>
                         </div>
                     </header>
+
+                    {siteConfig.header && (
+                        <div className="w-full bg-blue-50 border-b border-blue-100">
+                            <div className="max-w-4xl mx-auto px-4 py-3 text-sm text-gray-700"
+                                 dangerouslySetInnerHTML={{ __html: siteConfig.header }} />
+                        </div>
+                    )}
 
                     <main className="w-full max-w-4xl mx-auto px-4 pt-6 pb-4 flex-grow">
                         {activeTab === 'browser' && (
@@ -2488,12 +2525,18 @@
                         {activeTab === 'about' && (
                             <div>
                                 <h2 className="text-xl font-bold mb-4">About</h2>
-                                <p className="text-gray-700 mb-4">
-                                    OMW Cygnet is an experimental reformulation of Wordnet that is designed to eliminate conflicting records, and improve modularity. It extends the idea of the <a href="https://omwn.org/" className="text-blue-600 hover:underline">Open Multilingual Wordnet</a> and puts concepts at the core of the structure.
-                                </p>
-                                <p className="text-gray-700 mb-4">
-                                    Developed by Rowan Hall Maudslay and Francis Bond. Source code is available on <a href="https://github.com/rowanhm/cygnet" className="text-blue-600 hover:underline">GitHub</a>.
-                                </p>
+                                {siteConfig.about?.intro
+                                    ? <div className="text-gray-700 mb-4"
+                                           dangerouslySetInnerHTML={{ __html: siteConfig.about.intro }} />
+                                    : <>
+                                        <p className="text-gray-700 mb-4">
+                                            OMW Cygnet is an experimental reformulation of Wordnet that is designed to eliminate conflicting records, and improve modularity. It extends the idea of the <a href="https://omwn.org/" className="text-blue-600 hover:underline">Open Multilingual Wordnet</a> and puts concepts at the core of the structure.
+                                        </p>
+                                        <p className="text-gray-700 mb-4">
+                                            Developed by Rowan Hall Maudslay and Francis Bond. Source code is available on <a href="https://github.com/rowanhm/cygnet" className="text-blue-600 hover:underline">GitHub</a>.
+                                        </p>
+                                    </>
+                                }
                                 {dbStats && (
                                     <div className="border-t border-gray-200 pt-4 mb-4">
                                         <h3 className="font-medium text-sm text-gray-700 mb-3">Database statistics</h3>
@@ -2515,7 +2558,11 @@
                                 )}
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Citation</h3>
-                                    <p className="text-sm text-gray-600">If you use Cygnet, please cite <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Maudslay &amp; Bond (2026)</button> for Cygnet and <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Bond &amp; Foster (2013)</button> for the underlying Open Multilingual Wordnet, as well as the individual <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">wordnets</button> whose data you use.</p>
+                                    {siteConfig.about?.citation
+                                        ? <div className="text-sm text-gray-600"
+                                               dangerouslySetInnerHTML={{ __html: siteConfig.about.citation }} />
+                                        : <p className="text-sm text-gray-600">If you use Cygnet, please cite <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Maudslay &amp; Bond (2026)</button> for Cygnet and <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Bond &amp; Foster (2013)</button> for the underlying Open Multilingual Wordnet, as well as the individual <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">wordnets</button> whose data you use.</p>
+                                    }
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Language Data</h3>
@@ -2571,6 +2618,10 @@
                             <div>
                                 <h2 className="text-xl font-bold mb-4">Publications</h2>
                                 <ul className="space-y-4 mb-8">
+                                    {(siteConfig.publications || []).map((pub, i) => (
+                                        <li key={`cfg-pub-${i}`} className="text-sm text-gray-800"
+                                            dangerouslySetInnerHTML={{ __html: pub }} />
+                                    ))}
                                     <li className="text-sm text-gray-800">
                                         Rowan Hall Maudslay &amp; Francis Bond (2026). Cygnet: Refactoring the Open Multilingual Wordnet. In <em>Proceedings of the 15th International Conference on Language Resources and Evaluation (LREC 2026)</em>. (to appear)
                                     </li>
@@ -2684,16 +2735,20 @@
 
                     <footer className="mt-auto py-4">
                         <div className="max-w-4xl mx-auto px-4 border-t border-gray-200 pt-4">
-                            <div className="max-w-4xl mx-auto text-center text-sm text-gray-600">
-                                <div className="mb-2">
-                                    <span>Produced with the support of</span>
-                                </div>
-                                <div>
-                                    <a href="https://www.culturelab.psl.eu/" target="_blank" rel="noopener noreferrer" className="inline-block hover:opacity-80">
-                                        <img src="culturelab.png" alt="CultureLab" className="h-14 inline-block" />
-                                    </a>
-                                </div>
-                            </div>
+                            {siteConfig.footer
+                                ? <div className="max-w-4xl mx-auto text-center text-sm text-gray-600"
+                                       dangerouslySetInnerHTML={{ __html: siteConfig.footer }} />
+                                : <div className="max-w-4xl mx-auto text-center text-sm text-gray-600">
+                                    <div className="mb-2">
+                                        <span>Produced with the support of</span>
+                                    </div>
+                                    <div>
+                                        <a href="https://www.culturelab.psl.eu/" target="_blank" rel="noopener noreferrer" className="inline-block hover:opacity-80">
+                                            <img src="culturelab.png" alt="Culture Lab" className="h-14 inline-block" />
+                                        </a>
+                                    </div>
+                                  </div>
+                            }
                         </div>
                     </footer>
 

--- a/web/index.html
+++ b/web/index.html
@@ -671,7 +671,7 @@
                 (async () => {
                     try {
                         await _configPromise;
-                        const dbFile = _siteConfig.db || 'cygnet.db.gz';
+                        const dbFile = _siteConfig.db || _siteConfig.databases?.main?.filename || 'cygnet.db.gz';
                         setDbProgress('Loading sql.js...');
                         const SQL = await initSqlJs({
                             locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/${file}`
@@ -953,7 +953,7 @@
                 setProvError(null);
                 try {
                     await _configPromise;
-                    const provFile = _siteConfig.provenanceDb || 'provenance.db.gz';
+                    const provFile = _siteConfig.provenanceDb || _siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
                     let buf;
                     try {
                         const cached = await idbGet('provdb');
@@ -2586,14 +2586,17 @@
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Download</h3>
                                     {(() => {
-                                        const dbFile = siteConfig.db || 'cygnet.db.gz';
-                                        const provFile = siteConfig.provenanceDb || 'provenance.db.gz';
+                                        const dbFile = siteConfig.db || siteConfig.databases?.main?.filename || 'cygnet.db.gz';
+                                        const provFile = siteConfig.provenanceDb || siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
                                         const ghBase = 'https://github.com/rowanhm/cygnet/releases/latest/download/';
                                         const defaultDbs = [
                                             { filename: dbFile, url: ghBase + dbFile, description: 'The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages.' },
                                             { filename: provFile, url: ghBase + provFile, description: 'Provenance records tracing every data point back to its source wordnet and original identifier.' },
                                         ];
-                                        const dbs = siteConfig.databases || defaultDbs;
+                                        const rawDbs = siteConfig.databases;
+                                        const dbs = !rawDbs ? defaultDbs
+                                            : Array.isArray(rawDbs) ? rawDbs
+                                            : [rawDbs.main, rawDbs.provenance].filter(Boolean);
                                         return (<>
                                             <p className="text-sm text-gray-600 mb-3">
                                                 The {siteName} databases are available for download below. Both are SQLite databases compressed with gzip.

--- a/web/index.html
+++ b/web/index.html
@@ -675,7 +675,7 @@
                 (async () => {
                     try {
                         await _configPromise;
-                        const dbFile = _siteConfig.db || _siteConfig.databases?.main?.filename || 'cygnet.db.gz';
+                        const dbFile = _siteConfig.databases?.main?.filename || 'cygnet.db.gz';
                         setDbProgress('Loading sql.js...');
                         const SQL = await initSqlJs({
                             locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/${file}`
@@ -957,7 +957,7 @@
                 setProvError(null);
                 try {
                     await _configPromise;
-                    const provFile = _siteConfig.provenanceDb || _siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
+                    const provFile = _siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
                     let buf;
                     try {
                         const cached = await idbGet('provdb');
@@ -1064,14 +1064,15 @@
                         setActiveTab('browser');
                         const params = new URLSearchParams(queryString || '');
                         const urlSearch = params.get('q');
-                        const urlSearchLang = params.get('search_lang') ? new Set(params.get('search_lang').split(',')) : new Set();
+                        const rawSearchLang = params.get('search_lang');
+                        const urlSearchLang = rawSearchLang ? new Set(rawSearchLang.split(',')) : null;
                         const urlDisplayLang = params.get('display_lang');
                         const urlPos = params.get('pos') ? new Set(params.get('pos').split(',')) : new Set();
                         const urlSense = params.get('sense');
                         const urlSenseFilter = params.get('s');
                         const urlConcept = params.get('concept');
 
-                        setLanguageFilter(urlSearchLang);
+                        if (urlSearchLang !== null) setLanguageFilter(urlSearchLang);
                         if (urlDisplayLang) setDefinitionLanguage(urlDisplayLang);
                         setPosFilter(urlPos);
                         setSenseFilter(urlSenseFilter);
@@ -1094,7 +1095,14 @@
                             if (urlSearch) {
                                 setSearchTerm(urlSearch);
                                 setCurrentSearch(urlSearch);
-                                performSearch(urlSearch, urlSearchLang, urlPos, urlSenseFilter);
+                                // Use URL param if provided; otherwise fall back to
+                                // the local.json searchLanguage default (read directly
+                                // from _siteConfig to avoid stale closure over state).
+                                const def = _siteConfig.searchLanguage;
+                                const searchLang = urlSearchLang ?? (def
+                                    ? new Set(Array.isArray(def) ? def : [def])
+                                    : new Set());
+                                performSearch(urlSearch, searchLang, urlPos, urlSenseFilter);
                             }
                         }
                     }
@@ -2590,8 +2598,8 @@
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Download</h3>
                                     {(() => {
-                                        const dbFile = siteConfig.db || siteConfig.databases?.main?.filename || 'cygnet.db.gz';
-                                        const provFile = siteConfig.provenanceDb || siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
+                                        const dbFile = siteConfig.databases?.main?.filename || 'cygnet.db.gz';
+                                        const provFile = siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
                                         const ghBase = 'https://github.com/rowanhm/cygnet/releases/latest/download/';
                                         const defaultDbs = [
                                             { filename: dbFile, url: ghBase + dbFile, description: 'The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages.' },
@@ -2603,7 +2611,7 @@
                                             : [rawDbs.main, rawDbs.provenance].filter(Boolean);
                                         return (<>
                                             <p className="text-sm text-gray-600 mb-3">
-                                                The {siteName} databases are available for download below. Both are SQLite databases compressed with gzip.
+                                                The {siteName} databases are available for download below. These are SQLite databases compressed with gzip.
                                             </p>
                                             <ul className="space-y-3 mb-3">
                                                 {dbs.map((db, i) => {

--- a/web/index.html
+++ b/web/index.html
@@ -1768,10 +1768,14 @@
                                     siteConfig.logo
                                         ? (
                                             siteConfig.logo.url
-                                                ? <a href={siteConfig.logo.url} target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
+                                                ? <a href={siteConfig.logo.url} target="_blank" rel="noopener noreferrer" className="hover:opacity-80 flex items-center gap-2">
+                                                      {siteConfig.logo.name && <span className="text-3xl font-bold text-gray-800">{siteConfig.logo.name}</span>}
                                                       <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
                                                   </a>
-                                                : <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
+                                                : <span className="flex items-center gap-2">
+                                                      {siteConfig.logo.name && <span className="text-3xl font-bold text-gray-800">{siteConfig.logo.name}</span>}
+                                                      <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
+                                                  </span>
                                           )
                                         : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80 flex items-center gap-2">
                                               <span title="Open Multilingual Wordnet" className="text-3xl font-bold text-gray-800">OMW</span>

--- a/web/index.html
+++ b/web/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cygnet — A Network of Signs</title>
+    <title></title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/sql-wasm.js"></script>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦢</text></svg>">
+
     <style>
         .sense-box:hover { border-color: #60a5fa !important; }
         .sense-box:has(.concept-inner:hover) { border-color: #e5e7eb !important; }
@@ -86,8 +86,6 @@
         let _SQL = null;
         let _provDb = null;
 
-        // Prepared statement cache
-        const _stmtCache = {};
         function cachedExec(sql, params = []) {
             if (!_db) return [];
             try {
@@ -549,6 +547,17 @@
             });
         }
 
+        function useClickOutside(ref, open, onClose) {
+            useEffect(() => {
+                if (!open) return;
+                const handleClick = (e) => {
+                    if (ref.current && !ref.current.contains(e.target)) onClose();
+                };
+                document.addEventListener('mousedown', handleClick);
+                return () => document.removeEventListener('mousedown', handleClick);
+            }, [open]);
+        }
+
         // ========== MAIN COMPONENT ==========
         function DictionaryBrowser() {
             const [dbReady, setDbReady] = useState(false);
@@ -636,25 +645,8 @@
 
             useEffect(() => { hoveredNodeRef.current = hoveredNode; }, [hoveredNode]);
 
-            useEffect(() => {
-                if (!settingsOpen) return;
-                const handleClick = (e) => {
-                    if (settingsRef.current && !settingsRef.current.contains(e.target))
-                        setSettingsOpen(false);
-                };
-                document.addEventListener('mousedown', handleClick);
-                return () => document.removeEventListener('mousedown', handleClick);
-            }, [settingsOpen]);
-
-            useEffect(() => {
-                if (!helpOpen) return;
-                const handleClick = (e) => {
-                    if (helpRef.current && !helpRef.current.contains(e.target))
-                        setHelpOpen(false);
-                };
-                document.addEventListener('mousedown', handleClick);
-                return () => document.removeEventListener('mousedown', handleClick);
-            }, [helpOpen]);
+            useClickOutside(settingsRef, settingsOpen, () => setSettingsOpen(false));
+            useClickOutside(helpRef, helpOpen, () => setHelpOpen(false));
 
             useEffect(() => {
                 fetch('relations.json')
@@ -669,8 +661,9 @@
                     const { title, tagline, icon, searchLanguage, displayLanguage } = _siteConfig;
                     if (title) document.title = title + (tagline ? ` — ${tagline}` : '');
                     if (icon) {
-                        const link = document.querySelector("link[rel='icon']");
-                        if (link) link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${encodeURIComponent(icon)}</text></svg>`;
+                        let link = document.querySelector("link[rel='icon']");
+                        if (!link) { link = document.createElement('link'); link.rel = 'icon'; document.head.appendChild(link); }
+                        link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${encodeURIComponent(icon)}</text></svg>`;
                     }
                     if (displayLanguage && !localStorage.getItem('definitionLanguage')) {
                         setDefinitionLanguage(displayLanguage);
@@ -687,7 +680,8 @@
                 (async () => {
                     try {
                         await _configPromise;
-                        const dbFile = _siteConfig.databases?.main?.filename || 'cygnet.db.gz';
+                        const dbFile = _siteConfig.databases?.main?.filename;
+                        if (!dbFile) { setDbReady(true); return; }
                         setDbProgress('Loading sql.js...');
                         const SQL = await initSqlJs({
                             locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/${file}`
@@ -969,7 +963,8 @@
                 setProvError(null);
                 try {
                     await _configPromise;
-                    const provFile = _siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
+                    const provFile = _siteConfig.databases?.provenance?.filename;
+                    if (!provFile) { setProvLoading(false); return; }
                     let buf;
                     try {
                         const cached = await idbGet('provdb');
@@ -1746,7 +1741,7 @@
             }, []);
 
             const allPosValues = ['NOUN', 'VERB', 'ADJ', 'ADV', 'CONJ', 'ADP', 'NREF', 'UNK'];
-            const siteName = siteConfig.name || siteConfig.title || 'Cygnet';
+            const siteName = siteConfig.name || siteConfig.title || '';
 
             useEffect(() => { if (dbError) setActiveTab('about'); }, [dbError]);
 
@@ -1772,8 +1767,8 @@
                             <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-3">
                                     <button onClick={handleLogoClick} className="text-left hover:opacity-80 flex items-center gap-1.5">
-                                        <h1 className="text-4xl -mt-0.5">{siteConfig.icon || '🦢'}</h1>
-                                        <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title || 'Cygnet'}</h1>
+                                        {siteConfig.icon && <h1 className="text-4xl -mt-0.5">{siteConfig.icon}</h1>}
+                                        {siteConfig.title && <h1 className="text-3xl font-bold text-gray-800"> {siteConfig.title}</h1>}
                                     </button>
                                 </div>
                                 {siteConfig.logo !== null && (
@@ -1789,10 +1784,7 @@
                                                       <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
                                                   </span>
                                           )
-                                        : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80 flex items-center gap-2">
-                                              <span title="Open Multilingual Wordnet" className="text-3xl font-bold text-gray-800">OMW</span>
-                                              <img src="omw-logo.svg" alt="Open Multilingual Wordnet" className="h-10" />
-                                          </a>
+                                        : null
                                 )}
                             </div>
                             <nav className="flex items-end gap-3 mt-3 -mb-3 flex-wrap">
@@ -1982,9 +1974,8 @@
                                         <h2 className="font-bold text-xl mb-2">Error Loading Database</h2>
                                         <p className="mb-4 text-gray-700">{dbError}</p>
                                         <p className="text-sm text-gray-500">
-                                            On localhost, make sure <code>{siteConfig.databases?.main?.filename || 'cygnet.db.gz'}</code> is in the same directory as this HTML file.<br/>
-                                            In production, the database is fetched from the{' '}
-                                            <a href="https://github.com/rowanhm/cygnet/releases/latest" className="text-blue-600 hover:underline">latest GitHub release</a>.
+                                            {siteConfig.databases?.main?.filename && <>On localhost, make sure <code>{siteConfig.databases.main.filename}</code> is in the same directory as this HTML file.<br/></>}
+                                            In production, the database is fetched from the release URL configured in <code>local.json</code>.
                                             The release may still be building.
                                         </p>
                                     </div>
@@ -1992,7 +1983,7 @@
                                 {!dbReady && !dbError && (
                                     <div className="flex justify-center mt-16">
                                         <div className="text-center w-72">
-                                            <h1 className="text-4xl mb-4">🦢</h1>
+                                            {siteConfig.icon && <h1 className="text-4xl mb-4">{siteConfig.icon}</h1>}
                                             <p className="text-gray-600 mb-3">{dbProgress || 'Initializing...'}</p>
                                             {downloadProgress && (
                                                 <div>
@@ -2612,17 +2603,9 @@
                         {activeTab === 'about' && (
                             <div>
                                 <h2 className="text-xl font-bold mb-4">About</h2>
-                                {siteConfig.about?.intro
-                                    ? <div className="text-gray-700 mb-4"
-                                           dangerouslySetInnerHTML={{ __html: siteConfig.about.intro }} />
-                                    : <>
-                                        <p className="text-gray-700 mb-4">
-                                            OMW {siteName} is an experimental reformulation of Wordnet that is designed to eliminate conflicting records, and improve modularity. It extends the idea of the <a href="https://omwn.org/" className="text-blue-600 hover:underline">Open Multilingual Wordnet</a> and puts concepts at the core of the structure.
-                                        </p>
-                                        <p className="text-gray-700 mb-4">
-                                            Developed by Rowan Hall Maudslay and Francis Bond. Source code is available on <a href="https://github.com/rowanhm/cygnet" className="text-blue-600 hover:underline">GitHub</a>.
-                                        </p>
-                                    </>
+                                {siteConfig.about?.intro &&
+                                    <div className="text-gray-700 mb-4"
+                                         dangerouslySetInnerHTML={{ __html: siteConfig.about.intro }} />
                                 }
                                 {dbStats && (
                                     <div className="border-t border-gray-200 pt-4 mb-4">
@@ -2645,29 +2628,21 @@
                                 )}
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Citation</h3>
-                                    {siteConfig.about?.citation
-                                        ? <div className="text-sm text-gray-600"
-                                               dangerouslySetInnerHTML={{ __html: siteConfig.about.citation }} />
-                                        : <p className="text-sm text-gray-600">If you use {siteName}, please cite <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Maudslay &amp; Bond (2026)</button> for {siteName} and <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Bond &amp; Foster (2013)</button> for the underlying Open Multilingual Wordnet, as well as the individual <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">wordnets</button> whose data you use.</p>
+                                    {siteConfig.about?.citation &&
+                                        <div className="text-sm text-gray-600"
+                                             dangerouslySetInnerHTML={{ __html: siteConfig.about.citation }} />
                                     }
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Download</h3>
                                     {(() => {
-                                        const dbFile = siteConfig.databases?.main?.filename || 'cygnet.db.gz';
-                                        const provFile = siteConfig.databases?.provenance?.filename || 'provenance.db.gz';
-                                        const ghBase = 'https://github.com/rowanhm/cygnet/releases/latest/download/';
-                                        const defaultDbs = [
-                                            { filename: dbFile, url: ghBase + dbFile, description: 'The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages.' },
-                                            { filename: provFile, url: ghBase + provFile, description: 'Provenance records tracing every data point back to its source wordnet and original identifier.' },
-                                        ];
                                         const rawDbs = siteConfig.databases;
-                                        const dbs = !rawDbs ? defaultDbs
+                                        const dbs = !rawDbs ? []
                                             : Array.isArray(rawDbs) ? rawDbs
                                             : [rawDbs.main, rawDbs.provenance].filter(Boolean);
                                         return (<>
                                             <p className="text-sm text-gray-600 mb-3">
-                                                The {siteName} databases are available for download below. These are SQLite databases compressed with gzip.
+                                                The{siteName ? ` ${siteName}` : ''} databases are available for download below. These are SQLite databases compressed with gzip.
                                             </p>
                                             <ul className="space-y-3 mb-3">
                                                 {dbs.map((db, i) => {
@@ -2685,19 +2660,16 @@
                                                 })}
                                             </ul>
                                             <p className="text-sm text-gray-600">
-                                                The individual wordnets that make up {siteName} are each available from their respective projects — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets</button> tab for the full list with links.
+                                                The individual wordnets that make up{siteName ? ` ${siteName}` : ' this resource'} are each available from their respective projects — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets</button> tab for the full list with links.
                                             </p>
                                         </>);
                                     })()}
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Language Data</h3>
-                                    {siteConfig.about?.languageData
-                                        ? <div className="text-sm text-gray-600"
-                                               dangerouslySetInnerHTML={{ __html: siteConfig.about.languageData }} />
-                                        : <p className="text-sm text-gray-600">
-                                              The lexical data in {siteName} is drawn from a collection of open wordnets covering many languages — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets tab</button> for the full list of contributing projects and their licences. We are deeply grateful to every team that has worked to build and freely share these resources. Thanks to all the projects that have released their data openly!
-                                          </p>
+                                    {siteConfig.about?.languageData &&
+                                        <div className="text-sm text-gray-600"
+                                             dangerouslySetInnerHTML={{ __html: siteConfig.about.languageData }} />
                                     }
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
@@ -2752,15 +2724,6 @@
                                         <li key={`cfg-pub-${i}`} className="text-sm text-gray-800"
                                             dangerouslySetInnerHTML={{ __html: pub }} />
                                     ))}
-                                    <li className="text-sm text-gray-800">
-                                        Rowan Hall Maudslay &amp; Francis Bond (2026). Cygnet: Refactoring the Open Multilingual Wordnet. In <em>Proceedings of the 15th International Conference on Language Resources and Evaluation (LREC 2026)</em>. (to appear)
-                                    </li>
-                                    <li className="text-sm text-gray-800">
-                                        Francis Bond &amp; Ryan Foster (2013). Linking and extending an open multilingual wordnet. In <em>Proceedings of the 51st Annual Meeting of the Association for Computational Linguistics (ACL 2013)</em>. Sofia. pp. 1352–1362.
-                                    </li>
-                                    <li className="text-sm text-gray-800">
-                                        Francis Bond &amp; Kyonghee Paik (2012). A survey of wordnets and their licenses. In <em>Proceedings of the 6th Global WordNet Conference (GWC 2012)</em>. Matsue. pp. 64–71.
-                                    </li>
                                 </ul>
                                 <h2 className="text-xl font-bold mb-2">Wordnet Citations</h2>
                                 <p className="text-sm text-gray-500 italic mb-4">Citation data taken from each wordnet's source XML.</p>

--- a/web/index.html
+++ b/web/index.html
@@ -1128,6 +1128,7 @@
                     const sid = r.sense_id.toString();
                     if (sense && sid !== sense) return;
 
+                    const prev = senseMap[sid];
                     senseMap[sid] = {
                         id: sid,
                         l: r.lemma,
@@ -1135,7 +1136,7 @@
                         c: r.synset_id,
                         ind: r.ind,
                         ontological_category: r.pos,
-                        matched_rank: r.matched_rank,
+                        matched_rank: prev ? Math.max(prev.matched_rank, r.matched_rank) : r.matched_rank,
                     };
                 });
 

--- a/web/index.html
+++ b/web/index.html
@@ -603,6 +603,7 @@
             const [pathNotFound, setPathNotFound] = useState(false);
             const isPopStateRef = useRef(false);
             const isInitialLoadRef = useRef(true);
+            const initialUrlHandledRef = useRef(false);
             const hoverTimeoutRef = useRef(null);
             const isLoadingRelationsRef = useRef(false);
             const simulationRef = useRef(null);
@@ -653,7 +654,7 @@
                     if (title) document.title = title + (tagline ? ` — ${tagline}` : '');
                     if (icon) {
                         const link = document.querySelector("link[rel='icon']");
-                        if (link) link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${icon}</text></svg>`;
+                        if (link) link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${encodeURIComponent(icon)}</text></svg>`;
                     }
                     if (displayLanguage && !localStorage.getItem('definitionLanguage')) {
                         setDefinitionLanguage(displayLanguage);
@@ -683,7 +684,7 @@
                             if (cached) {
                                 let stale = false;
                                 const cachedFilename = await idbGet('db-filename');
-                                if (cachedFilename && cachedFilename !== dbFile) {
+                                if (!cachedFilename || cachedFilename !== dbFile) {
                                     stale = true;
                                 } else {
                                     try {
@@ -951,13 +952,14 @@
                 setProvLoading(true);
                 setProvError(null);
                 try {
+                    await _configPromise;
                     const provFile = _siteConfig.provenanceDb || 'provenance.db.gz';
                     let buf;
                     try {
                         const cached = await idbGet('provdb');
                         if (cached) {
                             const cachedFilename = await idbGet('provdb-filename');
-                            if (cachedFilename && cachedFilename !== provFile) {
+                            if (!cachedFilename || cachedFilename !== provFile) {
                                 await Promise.all([idbDel('provdb'), idbDel('provdb-filename')]);
                             } else {
                                 buf = new Uint8Array(cached);
@@ -1088,13 +1090,15 @@
                             if (urlSearch) {
                                 setSearchTerm(urlSearch);
                                 setCurrentSearch(urlSearch);
+                                performSearch(urlSearch, urlSearchLang, urlPos, urlSenseFilter);
                             }
                         }
                     }
                 };
 
-                // Handle initial URL
-                if (dbReady) {
+                // Handle initial URL (only once, even if effect re-runs due to dep changes)
+                if (dbReady && !initialUrlHandledRef.current) {
+                    initialUrlHandledRef.current = true;
                     const hash = window.location.hash;
                     if (hash && hash !== '#/search') handlePopState();
                 }

--- a/web/index.html
+++ b/web/index.html
@@ -117,7 +117,7 @@
         }
 
         const _SENSE_COLS = `s.rowid as sense_id, e.language_rowid as lang_rowid, syn.pos as pos,
-                       f.form as lemma, s.sense_index as ind, syn.rowid as synset_id`;
+                       f.form as lemma, f.rank as matched_rank, s.sense_index as ind, syn.rowid as synset_id`;
         const _SENSE_JOINS = `FROM forms f
                 JOIN entries e ON f.entry_rowid = e.rowid
                 JOIN senses s ON s.entry_rowid = e.rowid
@@ -649,11 +649,18 @@
             useEffect(() => {
                 _configPromise.then(() => {
                     setSiteConfig({..._siteConfig});
-                    const { title, tagline, icon } = _siteConfig;
+                    const { title, tagline, icon, searchLanguage, displayLanguage } = _siteConfig;
                     if (title) document.title = title + (tagline ? ` — ${tagline}` : '');
                     if (icon) {
                         const link = document.querySelector("link[rel='icon']");
                         if (link) link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${icon}</text></svg>`;
+                    }
+                    if (displayLanguage && !localStorage.getItem('definitionLanguage')) {
+                        setDefinitionLanguage(displayLanguage);
+                    }
+                    if (searchLanguage) {
+                        const langs = Array.isArray(searchLanguage) ? searchLanguage : [searchLanguage];
+                        setLanguageFilter(new Set(langs));
                     }
                 });
             }, []);
@@ -785,10 +792,13 @@
             };
 
             const toggleSynonyms = (senseId) => {
-                setSynonymsCollapsed(prev => ({
-                    ...prev,
-                    [senseId]: prev[senseId] === false ? true : false
-                }));
+                setSynonymsCollapsed(prev => {
+                    const sense = loadedSenses[senseId];
+                    const autoExpand = sense?.matched_rank > 0;
+                    const cur = prev[senseId];
+                    const isCurrentlyExpanded = cur === false || (autoExpand && cur !== true);
+                    return { ...prev, [senseId]: isCurrentlyExpanded ? true : false };
+                });
             };
 
             const loadConcept = useCallback((conceptId) => {
@@ -1120,12 +1130,14 @@
                         lg: r.lg,
                         c: r.synset_id,
                         ind: r.ind,
-                        ontological_category: r.pos
+                        ontological_category: r.pos,
+                        matched_rank: r.matched_rank,
                     };
                 });
 
                 setLoadedSenses(prev => ({ ...prev, ...senseMap }));
                 setCurrentSearchSenseIds(new Set(Object.keys(senseMap)));
+
                 setLoadingResults(false);
 
                 if (sense) {
@@ -1139,12 +1151,14 @@
                 const loadBatch = () => {
                     if (i >= senseIds.length) return;
                     const batch = senseIds.slice(i, i + BATCH_SIZE);
-                    const updates = {};
-                    batch.forEach(sid => {
-                        const full = querySense(parseInt(sid));
-                        if (full) updates[sid] = full;
+                    setLoadedSenses(prev => {
+                        const updates = {};
+                        batch.forEach(sid => {
+                            const full = querySense(parseInt(sid));
+                            if (full) updates[sid] = { ...full, matched_rank: prev[sid]?.matched_rank };
+                        });
+                        return { ...prev, ...updates };
                     });
-                    setLoadedSenses(prev => ({ ...prev, ...updates }));
                     i += BATCH_SIZE;
                     if (i < senseIds.length) setTimeout(loadBatch, 0);
                 };
@@ -2019,6 +2033,9 @@
                                                                                                 const [definition, defLang] = selectDef(concept?.d, definitionLanguage);
                                                                                                 const defIsFallback = defLang && defLang !== definitionLanguage;
                                                                                                 const hasExtra = !!(sense.v?.length || synonyms.length || sense.ex?.length || sense.sr?.length);
+                                                                                                const autoExpand = sense.matched_rank > 0;
+                                                                                                const isExpanded = synonymsCollapsed[sense.id] === false ||
+                                                                                                                  (autoExpand && synonymsCollapsed[sense.id] !== true);
                                                                                                 return (
                                                                                                     <div key={sense.id}
                                                                                                         className={`bg-gray-50 p-3 rounded border border-gray-200 sense-box ${hasExtra ? 'hover:border-blue-400 cursor-pointer' : ''}`}
@@ -2056,11 +2073,11 @@
                                                                                                             </div>
                                                                                                             {hasExtra && (
                                                                                                                 <div className="text-gray-500 text-sm pt-1 flex-shrink-0">
-                                                                                                                    {synonymsCollapsed[sense.id] === false ? '▼' : '▶'}
+                                                                                                                    {isExpanded ? '▼' : '▶'}
                                                                                                                 </div>
                                                                                                             )}
                                                                                                         </div>
-                                                                                                        {synonymsCollapsed[sense.id] === false && (
+                                                                                                        {isExpanded && (
                                                                                                             <div className="mt-2 space-y-2">
                                                                                                                 {sense.v && sense.v.length > 0 && (
                                                                                                                     <div className="text-sm text-gray-600">

--- a/web/index.html
+++ b/web/index.html
@@ -1021,7 +1021,7 @@
                     const hash = window.location.hash.slice(1);
                     const [path, queryString] = hash.split('?');
 
-                    if (['python', 'data', 'about', 'publications', 'wordnets'].includes(path?.replace('/', ''))) {
+                    if (['about', 'publications', 'wordnets'].includes(path?.replace('/', ''))) {
                         setActiveTab(path.replace('/', ''));
                     } else {
                         setActiveTab('browser');
@@ -1680,6 +1680,7 @@
             }, []);
 
             const allPosValues = ['NOUN', 'VERB', 'ADJ', 'ADV', 'CONJ', 'ADP', 'NREF', 'UNK'];
+            const siteName = siteConfig.name || siteConfig.title || 'Cygnet';
 
             useEffect(() => { if (dbError) setActiveTab('about'); }, [dbError]);
 
@@ -1720,7 +1721,7 @@
                                 )}
                             </div>
                             <nav className="flex items-end gap-3 mt-3 -mb-3">
-                                {['browser', 'python', 'data', 'about', 'publications', 'wordnets'].map(tab => (
+                                {['browser', 'about', 'publications', 'wordnets'].map(tab => (
                                     <button key={tab}
                                         onClick={() => setActiveTab(tab)}
                                         className={`px-4 py-2 rounded-t-lg border-b-2 transition-colors ${
@@ -2497,31 +2498,6 @@
                             </div>
                         )}
 
-                        {activeTab === 'python' && <div><h2 className="text-xl font-bold mb-4">Python Module</h2><p className="text-gray-600">Coming soon.</p></div>}
-                        {activeTab === 'data' && (
-                            <div>
-                                <h2 className="text-xl font-bold mb-4">Data Download</h2>
-                                <p className="text-gray-700 mb-6">
-                                    The Cygnet databases are available for download below. Both are SQLite databases compressed with gzip.
-                                </p>
-                                <ul className="space-y-4 mb-8">
-                                    <li className="text-sm text-gray-800">
-                                        <a href="https://github.com/rowanhm/cygnet/releases/latest/download/cygnet.db.gz" className="text-blue-600 hover:underline font-medium">cygnet.db.gz</a>
-                                        {' '}— The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages.
-                                    </li>
-                                    <li className="text-sm text-gray-800">
-                                        <a href="https://github.com/rowanhm/cygnet/releases/latest/download/provenance.db.gz" className="text-blue-600 hover:underline font-medium">provenance.db.gz</a>
-                                        {' '}— Provenance records tracing every data point back to its source wordnet and original identifier.
-                                    </li>
-                                </ul>
-                                <p className="text-gray-700 mb-4">
-                                    The individual wordnets that make up Cygnet are each available from their respective projects — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets</button> tab for the full list with links.
-                                </p>
-                                <p className="text-gray-700">
-                                    Source code for merging and displaying wordnets is available on <a href="https://github.com/rowanhm/cygnet" className="text-blue-600 hover:underline">GitHub</a>.
-                                </p>
-                            </div>
-                        )}
                         {activeTab === 'about' && (
                             <div>
                                 <h2 className="text-xl font-bold mb-4">About</h2>
@@ -2530,7 +2506,7 @@
                                            dangerouslySetInnerHTML={{ __html: siteConfig.about.intro }} />
                                     : <>
                                         <p className="text-gray-700 mb-4">
-                                            OMW Cygnet is an experimental reformulation of Wordnet that is designed to eliminate conflicting records, and improve modularity. It extends the idea of the <a href="https://omwn.org/" className="text-blue-600 hover:underline">Open Multilingual Wordnet</a> and puts concepts at the core of the structure.
+                                            OMW {siteName} is an experimental reformulation of Wordnet that is designed to eliminate conflicting records, and improve modularity. It extends the idea of the <a href="https://omwn.org/" className="text-blue-600 hover:underline">Open Multilingual Wordnet</a> and puts concepts at the core of the structure.
                                         </p>
                                         <p className="text-gray-700 mb-4">
                                             Developed by Rowan Hall Maudslay and Francis Bond. Source code is available on <a href="https://github.com/rowanhm/cygnet" className="text-blue-600 hover:underline">GitHub</a>.
@@ -2561,14 +2537,47 @@
                                     {siteConfig.about?.citation
                                         ? <div className="text-sm text-gray-600"
                                                dangerouslySetInnerHTML={{ __html: siteConfig.about.citation }} />
-                                        : <p className="text-sm text-gray-600">If you use Cygnet, please cite <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Maudslay &amp; Bond (2026)</button> for Cygnet and <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Bond &amp; Foster (2013)</button> for the underlying Open Multilingual Wordnet, as well as the individual <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">wordnets</button> whose data you use.</p>
+                                        : <p className="text-sm text-gray-600">If you use {siteName}, please cite <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Maudslay &amp; Bond (2026)</button> for {siteName} and <button onClick={() => setActiveTab('publications')} className="text-blue-600 hover:underline">Bond &amp; Foster (2013)</button> for the underlying Open Multilingual Wordnet, as well as the individual <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">wordnets</button> whose data you use.</p>
                                     }
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
+                                    <h3 className="font-medium text-sm text-gray-700 mb-2">Download</h3>
+                                    {(() => {
+                                        const dbFile = siteConfig.db || 'cygnet.db.gz';
+                                        const provFile = siteConfig.provenanceDb || 'provenance.db.gz';
+                                        const ghBase = 'https://github.com/rowanhm/cygnet/releases/latest/download/';
+                                        const defaultDbs = [
+                                            { filename: dbFile, url: ghBase + dbFile, description: 'The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages.' },
+                                            { filename: provFile, url: ghBase + provFile, description: 'Provenance records tracing every data point back to its source wordnet and original identifier.' },
+                                        ];
+                                        const dbs = siteConfig.databases || defaultDbs;
+                                        return (<>
+                                            <p className="text-sm text-gray-600 mb-3">
+                                                The {siteName} databases are available for download below. Both are SQLite databases compressed with gzip.
+                                            </p>
+                                            <ul className="space-y-3 mb-3">
+                                                {dbs.map((db, i) => (
+                                                    <li key={i} className="text-sm text-gray-800">
+                                                        <a href={db.url} className="text-blue-600 hover:underline font-medium">{db.filename}</a>
+                                                        {db.description ? <>{' '}— {db.description}</> : null}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                            <p className="text-sm text-gray-600">
+                                                The individual wordnets that make up {siteName} are each available from their respective projects — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets</button> tab for the full list with links.
+                                            </p>
+                                        </>);
+                                    })()}
+                                </div>
+                                <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Language Data</h3>
-                                    <p className="text-sm text-gray-600">
-                                        The lexical data in Cygnet is drawn from a collection of open wordnets covering many languages — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets tab</button> for the full list of contributing projects and their licences. We are deeply grateful to every team that has worked to build and freely share these resources. Thanks to all the projects that have released their data openly!
-                                    </p>
+                                    {siteConfig.about?.languageData
+                                        ? <div className="text-sm text-gray-600"
+                                               dangerouslySetInnerHTML={{ __html: siteConfig.about.languageData }} />
+                                        : <p className="text-sm text-gray-600">
+                                              The lexical data in {siteName} is drawn from a collection of open wordnets covering many languages — see the <button onClick={() => setActiveTab('wordnets')} className="text-blue-600 hover:underline">Wordnets tab</button> for the full list of contributing projects and their licences. We are deeply grateful to every team that has worked to build and freely share these resources. Thanks to all the projects that have released their data openly!
+                                          </p>
+                                    }
                                 </div>
                                 <div className="border-t border-gray-200 pt-4 mb-4">
                                     <h3 className="font-medium text-sm text-gray-700 mb-2">Images</h3>

--- a/web/index.html
+++ b/web/index.html
@@ -1764,9 +1764,13 @@
                                 </div>
                                 {siteConfig.logo !== null && (
                                     siteConfig.logo
-                                        ? <a href={siteConfig.logo.url || '#'} target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
-                                              <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
-                                          </a>
+                                        ? (
+                                            siteConfig.logo.url
+                                                ? <a href={siteConfig.logo.url} target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
+                                                      <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
+                                                  </a>
+                                                : <img src={siteConfig.logo.src} alt={siteConfig.logo.alt || ''} className="h-10" />
+                                          )
                                         : <a href="https://omwn.org" target="_blank" rel="noopener noreferrer" className="hover:opacity-80">
                                               <img src="omw-logo.svg" alt="Open Multilingual Wordnet" className="h-10" />
                                           </a>
@@ -1918,7 +1922,7 @@
                                         <h2 className="font-bold text-xl mb-2">Error Loading Database</h2>
                                         <p className="mb-4 text-gray-700">{dbError}</p>
                                         <p className="text-sm text-gray-500">
-                                            On localhost, make sure <code>cygnet.db.gz</code> is in the same directory as this HTML file.<br/>
+                                            On localhost, make sure <code>{siteConfig.databases?.main?.filename || 'cygnet.db.gz'}</code> is in the same directory as this HTML file.<br/>
                                             In production, the database is fetched from the{' '}
                                             <a href="https://github.com/rowanhm/cygnet/releases/latest" className="text-blue-600 hover:underline">latest GitHub release</a>.
                                             The release may still be building.

--- a/web/index.html
+++ b/web/index.html
@@ -589,6 +589,7 @@
             const [collapsedSections, setCollapsedSections] = useState({});
             const [synonymsCollapsed, setSynonymsCollapsed] = useState({});
             const [settingsOpen, setSettingsOpen] = useState(false);
+            const [helpOpen, setHelpOpen] = useState(false);
             const [relationsView, setRelationsView] = useState(() =>
                 localStorage.getItem('relationsView') || 'graph'
             );
@@ -619,6 +620,7 @@
             const menuRef = useRef(null);
             const menuInteractionRef = useRef(false);
             const settingsRef = useRef(null);
+            const helpRef = useRef(null);
             const hoveredNodeRef = useRef(null);
             const nodeSizeCache = useRef(new Map());
             const MAX_CACHE_SIZE = 200;
@@ -643,6 +645,16 @@
                 document.addEventListener('mousedown', handleClick);
                 return () => document.removeEventListener('mousedown', handleClick);
             }, [settingsOpen]);
+
+            useEffect(() => {
+                if (!helpOpen) return;
+                const handleClick = (e) => {
+                    if (helpRef.current && !helpRef.current.contains(e.target))
+                        setHelpOpen(false);
+                };
+                document.addEventListener('mousedown', handleClick);
+                return () => document.removeEventListener('mousedown', handleClick);
+            }, [helpOpen]);
 
             useEffect(() => {
                 fetch('relations.json')
@@ -1812,6 +1824,29 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div className="relative pb-0" ref={helpRef}>
+                                    <button onClick={() => setHelpOpen(o => !o)}
+                                        title="Help"
+                                        className={`px-3 py-2 rounded-t-lg border-b-2 transition-colors ${helpOpen ? 'bg-gray-50 border-blue-500 text-blue-700' : 'border-transparent text-gray-600 hover:text-gray-900 hover:bg-gray-50'}`}>
+                                        ?
+                                    </button>
+                                    {helpOpen && (
+                                        <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded shadow-lg z-20 w-80 p-4 text-sm text-gray-700 space-y-3">
+                                            <p>Type in the search box and press <kbd className="px-1 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs">Enter</kbd> to search. Results are <strong>senses</strong> — a word in a specific meaning. Click a sense to open its <strong>concept view</strong>, which shows relations (hypernyms, hyponyms, …) and lexicalizations across all languages.</p>
+                                            <div className="space-y-1">
+                                                <p className="font-semibold text-gray-500 text-xs uppercase tracking-wide">Search syntax</p>
+                                                <div><span className="font-mono font-semibold">dog</span> — exact word match</div>
+                                                <div><span className="font-mono font-semibold">dog*</span> or <span className="font-mono font-semibold">*ness</span> — wildcard (<span className="font-mono">*</span> = any characters, <span className="font-mono">?</span> = one)</div>
+                                                <div><span className="font-mono font-semibold">def:bright</span> — search inside definitions</div>
+                                                <div><span className="font-mono font-semibold">i1234</span> — look up concept by ILI</div>
+                                            </div>
+                                            <div className="space-y-1">
+                                                <p className="font-semibold text-gray-500 text-xs uppercase tracking-wide">Filtering &amp; display</p>
+                                                <p>Use <strong>⚙ Settings</strong> to filter results by language or part of speech, and to set the display language for definitions and synset labels.</p>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
                                 <div className="relative pb-0" ref={settingsRef}>
                                     <button onClick={() => setSettingsOpen(o => !o)}
                                         title="Settings"
@@ -1969,6 +2004,19 @@
                                                 </div>
                                             )}
                                         </div>
+                                    </div>
+                                )}
+                                {view === 'search' && dbReady && !currentSearch && !senseFilter && (
+                                    <div className="max-w-lg mx-auto mt-16 text-gray-600 space-y-5">
+                                        <p className="text-base">Search for a word, definition, or concept ILI — results are <strong>senses</strong> (a word in a specific meaning). Click any sense to open its <strong>concept view</strong>, which shows how concepts relate to each other and how they are expressed across languages.</p>
+                                        <div className="bg-gray-50 border border-gray-200 rounded p-4 space-y-1.5 text-sm">
+                                            <p className="font-semibold text-gray-500 text-xs uppercase tracking-wide mb-2">Search syntax</p>
+                                            <div><span className="font-mono font-semibold text-gray-800">dog</span> — exact word match</div>
+                                            <div><span className="font-mono font-semibold text-gray-800">dog*</span> or <span className="font-mono font-semibold text-gray-800">*ness</span> — wildcard (<span className="font-mono">*</span> = any characters, <span className="font-mono">?</span> = one character)</div>
+                                            <div><span className="font-mono font-semibold text-gray-800">def:bright</span> — search inside definitions</div>
+                                            <div><span className="font-mono font-semibold text-gray-800">i1234</span> or <span className="font-mono font-semibold text-gray-800">cili.i1234</span> — look up concept by ILI</div>
+                                        </div>
+                                        <p className="text-sm">Use <strong>⚙ Settings</strong> to filter results by language or part of speech, and to choose the display language for definitions and synset labels. This guide is always available via the <strong>?</strong> button.</p>
                                     </div>
                                 )}
                                 {view === 'search' && dbReady && (

--- a/web/index.html
+++ b/web/index.html
@@ -669,21 +669,30 @@
                             locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.2/${file}`
                         });
 
-                        // Check IndexedDB cache, validating against server mtime
+                        // Check IndexedDB cache, validating against filename and server mtime
                         let buf;
                         try {
                             const cached = await idbGet('db');
                             if (cached) {
                                 let stale = false;
-                                try {
-                                    const head = await fetch(DB_BASE + dbFile, { method: 'HEAD' });
-                                    const serverMtime = head.headers.get('last-modified') || head.headers.get('etag');
-                                    const cachedMtime = await idbGet('db-mtime');
-                                    if (serverMtime && serverMtime !== cachedMtime) stale = true;
-                                } catch (_) { /* offline — trust cache */ }
+                                const cachedFilename = await idbGet('db-filename');
+                                if (cachedFilename && cachedFilename !== dbFile) {
+                                    stale = true;
+                                } else {
+                                    try {
+                                        const head = await fetch(DB_BASE + dbFile, { method: 'HEAD' });
+                                        const serverMtime = head.headers.get('last-modified') || head.headers.get('etag');
+                                        const cachedMtime = await idbGet('db-mtime');
+                                        if (serverMtime && serverMtime !== cachedMtime) stale = true;
+                                    } catch (_) { /* offline — trust cache */ }
+                                }
                                 if (stale) {
                                     setDbProgress('Database updated, clearing cache...');
-                                    await Promise.all([idbDel('db'), idbDel('provdb'), idbDel('db-mtime')]);
+                                    await Promise.all([
+                                        idbDel('db'), idbDel('provdb'),
+                                        idbDel('db-mtime'), idbDel('db-filename'),
+                                        idbDel('provdb-filename'),
+                                    ]);
                                 } else {
                                     setDbProgress('Loading from cache...');
                                     buf = new Uint8Array(cached);
@@ -736,6 +745,7 @@
                             setDbProgress('Caching for next visit...');
                             try {
                                 await idbPut('db', buf.buffer);
+                                await idbPut('db-filename', dbFile);
                                 if (serverMtime) await idbPut('db-mtime', serverMtime);
                             } catch (e) {
                                 console.warn('IndexedDB cache write failed:', e);
@@ -931,16 +941,24 @@
                 setProvLoading(true);
                 setProvError(null);
                 try {
+                    const provFile = _siteConfig.provenanceDb || 'provenance.db.gz';
                     let buf;
                     try {
                         const cached = await idbGet('provdb');
-                        if (cached) buf = new Uint8Array(cached);
+                        if (cached) {
+                            const cachedFilename = await idbGet('provdb-filename');
+                            if (cachedFilename && cachedFilename !== provFile) {
+                                await Promise.all([idbDel('provdb'), idbDel('provdb-filename')]);
+                            } else {
+                                buf = new Uint8Array(cached);
+                            }
+                        }
                     } catch (e) {
                         console.warn('IndexedDB provenance cache read failed:', e);
                     }
 
                     if (!buf) {
-                        const response = await fetch(DB_BASE + (_siteConfig.provenanceDb || 'provenance.db.gz'));
+                        const response = await fetch(DB_BASE + provFile);
                         if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
                         const ds = new DecompressionStream('gzip');
                         const reader = response.body.pipeThrough(ds).getReader();
@@ -955,7 +973,10 @@
                         buf = new Uint8Array(loaded);
                         let offset = 0;
                         for (const chunk of chunks) { buf.set(chunk, offset); offset += chunk.length; }
-                        try { await idbPut('provdb', buf.buffer); } catch (e) {
+                        try {
+                            await idbPut('provdb', buf.buffer);
+                            await idbPut('provdb-filename', provFile);
+                        } catch (e) {
                             console.warn('IndexedDB provenance cache write failed:', e);
                         }
                     }

--- a/web/local.json
+++ b/web/local.json
@@ -1,0 +1,40 @@
+{
+  "title":   "Cygnet",
+  "name":    "Cygnet",
+  "tagline": "A Network of Signs",
+  "icon":    "🦢",
+
+  "databases": {
+    "main": {
+      "filename":    "cygnet.db.gz",
+      "url":         "https://github.com/omwn/cygnet/releases/latest/download/cygnet.db.gz",
+      "description": "The main lexical database, containing synsets, entries, senses, definitions, examples, and pronunciations across all languages."
+    },
+    "provenance": {
+      "filename":    "provenance.db.gz",
+      "url":         "https://github.com/omwn/cygnet/releases/latest/download/provenance.db.gz",
+      "description": "Provenance records tracing every data point back to its source wordnet and original identifier."
+    }
+  },
+
+  "logo": {
+    "src":  "omw-logo.svg",
+    "url":  "https://omwn.org",
+    "alt":  "Open Multilingual Wordnet",
+    "name": "OMW"
+  },
+
+  "displayLanguage": "en",
+
+  "about": {
+    "intro": "<p>OMW Cygnet is an experimental reformulation of Wordnet that is designed to eliminate conflicting records and improve modularity. It extends the idea of the <a href='https://omwn.org/' style='text-decoration:underline'>Open Multilingual Wordnet</a> and puts concepts at the core of the structure.</p><p>Developed by Rowan Hall Maudslay and Francis Bond. Source code is available on <a href='https://github.com/omwn/cygnet' style='text-decoration:underline'>GitHub</a>.</p>",
+    "citation": "If you use Cygnet, please cite <a href='https://aclanthology.org/' style='text-decoration:underline'>Maudslay &amp; Bond (2026)</a> for Cygnet and <a href='https://aclanthology.org/P13-1133/' style='text-decoration:underline'>Bond &amp; Foster (2013)</a> for the underlying Open Multilingual Wordnet, as well as the individual wordnets whose data you use — see the Publications tab.",
+    "languageData": "The lexical data in Cygnet is drawn from a collection of open wordnets covering many languages — see the Wordnets tab for the full list of contributing projects and their licences. We are deeply grateful to every team that has worked to build and freely share these resources."
+  },
+
+  "publications": [
+    "Rowan Hall Maudslay &amp; Francis Bond (2026). Cygnet: Refactoring the Open Multilingual Wordnet. In <em>Proceedings of the 15th International Conference on Language Resources and Evaluation (LREC 2026)</em>. (to appear)",
+    "Francis Bond &amp; Ryan Foster (2013). <a href='https://aclanthology.org/P13-1133/' style='text-decoration:underline'>Linking and extending an open multilingual wordnet</a>. In <em>Proceedings of the 51st Annual Meeting of the Association for Computational Linguistics (ACL 2013)</em>. Sofia. pp. 1352–1362.",
+    "Francis Bond &amp; Kyonghee Paik (2012). A survey of wordnets and their licenses. In <em>Proceedings of the 6th Global WordNet Conference (GWC 2012)</em>. Matsue. pp. 64–71."
+  ]
+}


### PR DESCRIPTION
## Summary

- **`local.json` site config**: new fields `name`, `databases`, `about.languageData`, `searchLanguage`, `displayLanguage` let downstream projects brand and configure the UI without touching `index.html`
- **Tabs**: removed Python tab; merged Data into About
- **Variant form search**: searching a variant form (rank > 0) auto-expands the Variants section on the matching sense card
- **IndexedDB cache invalidation**: cache is discarded when the configured DB filename changes (prevents cross-deployment collisions)
- **`build.sh --work-dir`**: run the pipeline in an external directory, enabling downstream projects to call cygnet's build script directly
- **`CUSTOMIZE.md`**: new guide for using Cygnet in a downstream project (with OJW as a worked example)
- **`WEB_UI.md`**: updated to reflect removed tabs, new state variables, and `local.json` config

## Test plan

- [ ] All 74 Playwright UI tests pass (`uv run pytest tests/test_ui.py -v`)
- [ ] Search "doggo" → Variants section auto-expands
- [ ] Search "dog" → Variants section does not auto-expand
- [ ] `local.json` with `searchLanguage`/`displayLanguage` sets correct defaults on page load
- [ ] About tab shows Download section with configurable DB entries
- [ ] Python tab and Data tab are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)